### PR TITLE
Handle club names case-insensitively

### DIFF
--- a/test_benchmarks.py
+++ b/test_benchmarks.py
@@ -21,3 +21,15 @@ def test_driver_benchmark_mixed():
     }
     result = check_benchmark("Driver", stats)
     assert any("❌" in line for line in result)
+
+
+def test_club_name_case_insensitive():
+    """`check_benchmark` should match club names regardless of case."""
+    stats = {
+        'Carry': 230,
+        'Smash Factor': 1.46,
+        'Launch Angle': 13,
+        'Backspin': 2500
+    }
+    result = check_benchmark("driver", stats)
+    assert all("✅" in line for line in result)

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -33,9 +33,14 @@ def check_benchmark(club_name, stats):
     benchmarks = get_benchmarks()
     result_lines = []
 
+    # Normalize club name for case-insensitive matching. The original
+    # implementation performed a direct substring check which failed for
+    # club names using different capitalization (e.g. "driver" vs
+    # "Driver").
     target_type = None
+    club_name_lower = club_name.lower()
     for key in benchmarks:
-        if key in club_name:
+        if key.lower() in club_name_lower:
             target_type = key
             break
 


### PR DESCRIPTION
## Summary
- ensure benchmark lookups match club names regardless of capitalization
- add regression test for lowercase club names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee5d06054833089926427511a4ffd