### PR TITLE
Add tests for benchmark edge cases

### DIFF
--- a/test_benchmarks.py
+++ b/test_benchmarks.py
@@ -1,5 +1,7 @@
 # test_benchmarks.py
 
+import pytest
+
 from utils.benchmarks import check_benchmark
 
 def test_driver_benchmark_all_good():
@@ -21,3 +23,42 @@ def test_driver_benchmark_mixed():
     }
     result = check_benchmark("Driver", stats)
     assert any("❌" in line for line in result)
+
+
+def test_no_benchmark_available():
+    """Return message for clubs without benchmarks."""
+    stats = {'Carry': 100}
+    result = check_benchmark("Putter", stats)
+    assert result == ["No benchmark available for this club."]
+
+
+@pytest.mark.parametrize(
+    "stats, all_pass",
+    [
+        (
+            {
+                'Carry': 150,
+                'Smash Factor': 1.33,
+                'Launch Angle': 17,
+                'Backspin': 6000,
+            },
+            True,
+        ),
+        (
+            {
+                'Carry': 140,
+                'Smash Factor': 1.30,
+                'Launch Angle': 22,
+                'Backspin': 4000,
+            },
+            False,
+        ),
+    ],
+)
+def test_7_iron_benchmarks(stats, all_pass):
+    """Check benchmarks for 7 Iron with passing and failing metrics."""
+    result = check_benchmark("7 Iron", stats)
+    if all_pass:
+        assert all("✅" in line for line in result)
+    else:
+        assert any("❌" in line for line in result)


### PR DESCRIPTION
## Summary
- add test ensuring clubs without benchmarks return proper message
- add parametrized tests for 7 Iron benchmarks covering passing and failing metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ee6f2133c8330a5880909285790a0