### PR TITLE
Fix column rename syntax

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,14 @@ else:
                     if 'Date' in df.columns:
                         df['Date'] = pd.to_datetime(df['Date'], errors='coerce')
                     if 'Club Type' in df.columns:
-                        df.rename(columns={'Club Type': 'Club', 'Carry Distance': 'Carry', 'Total Distance': 'Total'}, inplace=True)
+                        df.rename(
+                            columns={
+                                'Club Type': 'Club',
+                                'Carry Distance': 'Carry',
+                                'Total Distance': 'Total',
+                            },
+                            inplace=True,
+                        )
                         df['Carry'] = pd.to_numeric(df['Carry'], errors='coerce')
                         df['Total'] = pd.to_numeric(df['Total'], errors='coerce')
                     dfs.append(df)


### PR DESCRIPTION
## Summary
- fix column rename statement for Garmin R10 CSV loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ee6c53e508330a650115b143b3efb