### PR TITLE
Fix case-insensitive benchmark lookup

### DIFF
--- a/test_benchmarks.py
+++ b/test_benchmarks.py
@@ -14,6 +14,18 @@ def test_driver_benchmark_all_good():
     result = check_benchmark("Driver", stats)
     assert all("✅" in line for line in result)
 
+
+def test_driver_case_insensitive():
+    """Benchmark lookup should be case-insensitive."""
+    stats = {
+        'Carry': 230,
+        'Smash Factor': 1.46,
+        'Launch Angle': 13,
+        'Backspin': 2500,
+    }
+    result = check_benchmark("driver", stats)
+    assert all("✅" in line for line in result)
+
 def test_driver_benchmark_mixed():
     stats = {
         'Carry': 210,

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -34,8 +34,17 @@ def check_benchmark(club_name, stats):
     result_lines = []
 
     target_type = None
+    # Perform a case-insensitive lookup for the club name.  The Garmin
+    # data sometimes provides club names in lowercase (e.g. "driver")
+    # or with different capitalisation.  The previous implementation
+    # checked using a simple substring search which failed when the
+    # capitalisation differed, causing the function to think there was
+    # no benchmark available.  Normalising both strings avoids this
+    # issue and ensures that valid benchmarks are returned regardless of
+    # case.
+    club_name_lower = club_name.lower()
     for key in benchmarks:
-        if key in club_name:
+        if key.lower() in club_name_lower:
             target_type = key
             break
 


### PR DESCRIPTION
## Summary
- Handle club name lookup in `check_benchmark` without case sensitivity
- Add regression test for lowercase club name usage in benchmarks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee8b8a1fc8330a9a307182b66963c