### PR TITLE
Fix minor typos in docs and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Streamlit-based app for analyzing and improving your golf performance using da
 - Automatically groups data by session and club
 
 ### 📊 Dashboard View
-- Aggregates club data (Carry, Smash, Launch Angle, etc.)
+- Aggregates club data (Carry, Smash Factor, Launch Angle, etc.)
 - Optional filters to remove outliers or poor contact shots
 - Interactive Plotly charts (Mean vs. Median vs. Std Dev)
 - Smart session and club filtering

--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -159,7 +159,7 @@ else:
                      delta_color="inverse")
 
     st.markdown("""
-    ### Statistic Explanations
+    ### Statistics Explanations
     - **Mean**: Average performance; e.g., mean Carry is your typical distance (aim >220 yds for Driver).
     - **Median**: Middle value, less affected by outliers; compare to mean for consistency.
     - **Std**: Variability; lower values (e.g., <10% of mean) indicate consistent shots.


### PR DESCRIPTION
## Summary
- clarify dashboard bullet by spelling out Smash Factor
- correct dashboard heading to "Statistics Explanations"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee93c90008330b8e15b6f8ff8afc9