### PR TITLE
Add drill recommendations based on club stats

### DIFF
--- a/test_drill_recommendations.py
+++ b/test_drill_recommendations.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+from utils.drill_recommendations import recommend_drills
+
+
+def test_recommends_low_smash():
+    df = pd.DataFrame({
+        'Club Type': ['Driver', 'Driver'],
+        'Carry Distance': [230, 232],
+        'Smash Factor': [1.40, 1.46],
+        'Launch Angle': [12, 13],
+    })
+    recs = recommend_drills(df)
+    issues = [r.issue for r in recs['Driver']]
+    assert "Low smash factor" in issues
+
+
+def test_no_issues_for_good_pw():
+    df = pd.DataFrame({
+        'Club Type': ['PW', 'PW'],
+        'Carry Distance': [120, 121],
+        'Smash Factor': [1.26, 1.27],
+        'Launch Angle': [26, 27],
+    })
+    recs = recommend_drills(df)
+    assert recs['PW'] == []
+
+
+def test_inconsistent_carry():
+    df = pd.DataFrame({
+        'Club Type': ['7 Iron'] * 3,
+        'Carry Distance': [130, 150, 170],
+        'Smash Factor': [1.33, 1.34, 1.32],
+        'Launch Angle': [16, 17, 18],
+    })
+    recs = recommend_drills(df)
+    issues = [r.issue for r in recs['7 Iron']]
+    assert "Inconsistent carry distance" in issues
+
+
+def test_poor_launch_angle():
+    df = pd.DataFrame({
+        'Club Type': ['7 Iron'] * 2,
+        'Carry Distance': [150, 152],
+        'Smash Factor': [1.33, 1.34],
+        'Launch Angle': [25, 26],
+    })
+    recs = recommend_drills(df)
+    issues = [r.issue for r in recs['7 Iron']]
+    assert "Poor launch angle" in issues

--- a/utils/drill_recommendations.py
+++ b/utils/drill_recommendations.py
@@ -1,0 +1,89 @@
+"""Utility for recommending practice drills based on club stats.
+
+This module analyses a dataframe of Garmin R10 shots and returns
+issue/drill recommendations for each club.  The recommendations are
+loosely inspired by Jon Sherman style practice routines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+from .benchmarks import get_benchmarks
+
+
+@dataclass
+class Recommendation:
+    """Represents a practice recommendation for a club."""
+
+    issue: str
+    drill: str
+
+
+_DRILLS: Dict[str, Recommendation] = {
+    "low_smash": Recommendation(
+        issue="Low smash factor",
+        drill="Use Jon Sherman's tee gate drill to improve center-face contact.",
+    ),
+    "inconsistent_carry": Recommendation(
+        issue="Inconsistent carry distance",
+        drill="Practice Jon Sherman's three-ball ladder drill for better distance control.",
+    ),
+    "poor_launch": Recommendation(
+        issue="Poor launch angle",
+        drill="Try Jon Sherman's low-point control drill to dial in launch.",
+    ),
+}
+
+
+def _match_benchmark(club: str) -> Dict[str, float]:
+    """Return benchmark dict matching ``club`` by name (case-insensitive)."""
+
+    club_lower = club.lower()
+    for name, bench in get_benchmarks().items():
+        if name.lower() in club_lower:
+            return bench
+    return {}
+
+
+def recommend_drills(df: pd.DataFrame) -> Dict[str, List[Recommendation]]:
+    """Generate drill recommendations for each club in ``df``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least ``Club Type``, ``Carry Distance``,
+        ``Smash Factor`` and ``Launch Angle`` columns.
+
+    Returns
+    -------
+    dict
+        Mapping of club name to a list of :class:`Recommendation` objects.
+    """
+
+    recommendations: Dict[str, List[Recommendation]] = {}
+
+    for club, club_df in df.groupby("Club Type"):
+        recs: List[Recommendation] = []
+        bench = _match_benchmark(club)
+
+        if bench.get("Smash Factor") is not None:
+            if club_df["Smash Factor"].min() < bench["Smash Factor"]:
+                recs.append(_DRILLS["low_smash"])
+
+        carry_std = club_df["Carry Distance"].std(ddof=0)
+        if pd.notna(carry_std) and carry_std > 8:
+            recs.append(_DRILLS["inconsistent_carry"])
+
+        if bench.get("Launch Angle") is not None:
+            mean_launch = club_df["Launch Angle"].mean()
+            low, high = bench["Launch Angle"]
+            if mean_launch < low or mean_launch > high:
+                recs.append(_DRILLS["poor_launch"])
+
+        recommendations[club] = recs
+
+    return recommendations


### PR DESCRIPTION
## Summary
- add `recommend_drills` utility that flags low smash factor, inconsistent carry, or poor launch and suggests Jon Sherman style drills
- cover new utility with unit tests for multiple issue scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eedc5727483308ba0c9575aed5736