### PR TITLE
feat: add assistants summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ A Streamlit-based app for analyzing and improving your golf performance using da
 - Built-in feedback for practice priorities
 
 ### 🧠 AI Insights (Optional)
-- Enter OpenAI key to generate coaching-style analysis
-- Evaluates consistency, contact, and improvement areas
+- Requires `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` environment variables
+- Generates coaching-style analysis and per-club summaries
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -11,8 +11,8 @@ services:
         value: 8501
       - key: OPENAI_API_KEY
         fromEnv: OPENAI_API_KEY
-      - key: ASSISTANT_ID
-        fromEnv: ASSISTANT_ID
+      - key: OPENAI_ASSISTANT_ID
+        fromEnv: OPENAI_ASSISTANT_ID
       - key: PASSWORD
         fromEnv: PASSWORD
     dockerCommand: streamlit run app.py --server.port $PORT --server.enableCORS false


### PR DESCRIPTION
## Summary
- use OpenAI Assistants API for per-club summaries
- read API credentials from environment variables
- document new OPENAI_ASSISTANT_ID variable and config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eee5d4704833099fce99ed333d4c8