### PR TITLE
Handle wedge name aliases in benchmarks

### DIFF
--- a/test_benchmarks.py
+++ b/test_benchmarks.py
@@ -26,6 +26,16 @@ def test_driver_case_insensitive():
     result = check_benchmark("driver", stats)
     assert all("✅" in line for line in result)
 
+
+def test_pitching_wedge_alias():
+    """Full club names such as 'Pitching Wedge' should map to PW benchmarks."""
+    stats = {
+        'Smash Factor': 1.26,
+        'Backspin': 9000,
+    }
+    result = check_benchmark("Pitching Wedge", stats)
+    assert all("✅" in line for line in result)
+
 def test_driver_benchmark_mixed():
     stats = {
         'Carry': 210,

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -34,15 +34,20 @@ def check_benchmark(club_name, stats):
     result_lines = []
 
     target_type = None
-    # Perform a case-insensitive lookup for the club name.  The Garmin
-    # data sometimes provides club names in lowercase (e.g. "driver")
-    # or with different capitalisation.  The previous implementation
-    # checked using a simple substring search which failed when the
-    # capitalisation differed, causing the function to think there was
-    # no benchmark available.  Normalising both strings avoids this
-    # issue and ensures that valid benchmarks are returned regardless of
-    # case.
+    # Perform a case-insensitive lookup for the club name.  Garmin data
+    # sometimes provides club names in lowercase (e.g. "driver") or with
+    # different capitalisation.  Additionally, some names such as
+    # "Pitching Wedge" are written out in full rather than using the
+    # abbreviations stored in ``benchmarks``.  Normalising both strings and
+    # handling a few common aliases avoids the function thinking a club has
+    # no benchmark available.
     club_name_lower = club_name.lower()
+    aliases = {"pitching wedge": "pw", "sand wedge": "sw"}
+    for alias, repl in aliases.items():
+        if alias in club_name_lower:
+            club_name_lower = club_name_lower.replace(alias, repl)
+            break
+
     for key in benchmarks:
         if key.lower() in club_name_lower:
             target_type = key

--- a/utils/drill_recommendations.py
+++ b/utils/drill_recommendations.py
@@ -43,6 +43,12 @@ def _match_benchmark(club: str) -> Dict[str, float]:
     """Return benchmark dict matching ``club`` by name (case-insensitive)."""
 
     club_lower = club.lower()
+    aliases = {"pitching wedge": "pw", "sand wedge": "sw"}
+    for alias, repl in aliases.items():
+        if alias in club_lower:
+            club_lower = club_lower.replace(alias, repl)
+            break
+
     for name, bench in get_benchmarks().items():
         if name.lower() in club_lower:
             return bench


### PR DESCRIPTION
## Summary
- normalise club names and handle Pitching/Sand Wedge aliases in benchmark lookup
- apply the same alias logic when matching benchmarks for drill recommendations
- add regression test for Pitching Wedge alias

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eef5d3f5c83308b27048de9f8f70c