### PR TITLE
Centralize sidebar navigation for Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import numpy as np
 from datetime import datetime
 import os
 
+from utils.sidebar import render_sidebar
+
 # Password validation
 st.set_page_config(page_title="Garmin R10 Analyzer", layout="centered")
 password = st.text_input("Enter Password", type="password")
@@ -14,29 +16,27 @@ if not correct_password:
 elif password != correct_password:
     st.error("Incorrect password. Access denied.")
 else:
+    render_sidebar()
     st.title("Garmin R10 Multi-Session Analyzer")
-    st.markdown("Upload your Garmin R10 CSV files below to get started. View full data or analyze summaries via the sidebar.")
+    st.markdown(
+        "Upload your Garmin R10 CSV files below to get started. View full data or analyze summaries via the sidebar."
+    )
 
     # CSS for compact tables and navigation styling
-    st.markdown("""
+    st.markdown(
+        """
         <style>
             .dataframe {font-size: small; overflow-x: auto;}
             .sidebar .sidebar-content {background-color: #f0f2f6; padding: 10px;}
             .sidebar a {color: #2ca02c; text-decoration: none;}
             .sidebar a:hover {background-color: #228B22; text-decoration: underline;}
         </style>
-    """, unsafe_allow_html=True)
-
-    # Consistent sidebar navigation with links
-    st.sidebar.title("Navigation")
-    st.sidebar.markdown("""
-    - [🏠 Home (Upload CSVs)](/)
-    - [📋 Sessions Viewer](/1_Sessions_Viewer)
-    - [📊 Dashboard](/0_dashboard)
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 
     # Conditional guidance based on data
-    if 'df_all' not in st.session_state or st.session_state['df_all'].empty:
+    if "df_all" not in st.session_state or st.session_state["df_all"].empty:
         st.sidebar.warning("Upload data to enable all features.")
     else:
         st.sidebar.success("Data loaded. Explore sessions or dashboard!")

--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -5,11 +5,14 @@ import openai
 import plotly.express as px
 import os
 
+from utils.sidebar import render_sidebar
+
 st.set_page_config(layout="centered")
 st.header("📊 Dashboard – Club Summary")
 
 # CSS for compact tables and improved layout
-st.markdown("""
+st.markdown(
+    """
     <style>
         .dataframe {font-size: small; overflow-x: auto; border: 1px solid #ddd; border-radius: 5px;}
         .sidebar .sidebar-content {background-color: #f0f2f6; padding: 10px;}
@@ -17,18 +20,14 @@ st.markdown("""
         .sidebar a:hover {background-color: #228B22; color: white; text-decoration: none; border-radius: 3px;}
         .stExpander > div {border: 1px solid #ddd; border-radius: 5px;}
     </style>
-""", unsafe_allow_html=True)
+""",
+    unsafe_allow_html=True,
+)
 
-# Consistent sidebar navigation with single set of links
-st.sidebar.title("Navigation")
-st.sidebar.markdown("""
-- <a href="?" style="color: #2ca02c;">🏠 Home (Upload CSVs)</a>
-- <a href="?page=1_Sessions_Viewer" style="color: #2ca02c;">📋 Sessions Viewer</a>
-- <a href="?page=0_dashboard" style="color: #2ca02c;">📊 Dashboard</a>
-""", unsafe_allow_html=True)
+render_sidebar()
 
 # Conditional guidance
-if 'df_all' not in st.session_state or st.session_state['df_all'].empty:
+if "df_all" not in st.session_state or st.session_state["df_all"].empty:
     st.sidebar.warning("Upload data to enable all features.")
 else:
     st.sidebar.success("Data loaded. Explore sessions or dashboard!")

--- a/pages/1_Sessions_Viewer.py
+++ b/pages/1_Sessions_Viewer.py
@@ -1,34 +1,33 @@
 import streamlit as st
 import pandas as pd
 
+from utils.sidebar import render_sidebar
+
 st.set_page_config(layout="centered")
 st.header("📋 Sessions Viewer")
 
 # CSS for compact tables
-st.markdown("""
+st.markdown(
+    """
     <style>
         .dataframe {font-size: small; overflow-x: auto;}
         .sidebar .sidebar-content {background-color: #f0f2f6; padding: 10px;}
         .sidebar a {color: #2ca02c; text-decoration: none;}
         .sidebar a:hover {background-color: #228B22; text-decoration: underline;}
     </style>
-""", unsafe_allow_html=True)
+""",
+    unsafe_allow_html=True,
+)
 
-# Consistent sidebar navigation with links
-st.sidebar.title("Navigation")
-st.sidebar.markdown("""
-- [🏠 Home (Upload CSVs)](/)
-- [📋 Sessions Viewer](/1_Sessions_Viewer)
-- [📊 Dashboard](/0_dashboard)
-""", unsafe_allow_html=True)
+render_sidebar()
 
 # Conditional guidance
-if 'df_all' not in st.session_state or st.session_state['df_all'].empty:
+if "df_all" not in st.session_state or st.session_state["df_all"].empty:
     st.sidebar.warning("Upload data to enable all features.")
 else:
     st.sidebar.success("Data loaded. Explore sessions or dashboard!")
 
-df_all = st.session_state.get('df_all')
+df_all = st.session_state.get("df_all")
 
 if df_all is None or df_all.empty:
     st.warning("No session data uploaded yet. Go to the Home page to upload.")

--- a/pages/2_Benchmark_Report.py
+++ b/pages/2_Benchmark_Report.py
@@ -2,47 +2,53 @@ import streamlit as st
 import pandas as pd
 from utils.benchmarks import check_benchmark
 
+from utils.sidebar import render_sidebar
+
 st.set_page_config(layout="centered")
 st.header("📌 Benchmark Report – Club Performance vs. Goals")
 
-# Sidebar navigation consistency
-st.sidebar.title("Navigation")
-st.sidebar.markdown("""
-- [🏠 Home (Upload CSVs)](/)
-- [📋 Sessions Viewer](/1_Sessions_Viewer)
-- [📊 Dashboard](/0_dashboard)
-- [📌 Benchmark Report](/2_Benchmark_Report)
-""", unsafe_allow_html=True)
+render_sidebar()
 
-if 'df_all' not in st.session_state or st.session_state['df_all'].empty:
+if "df_all" not in st.session_state or st.session_state["df_all"].empty:
     st.warning("No session data found. Please upload data on the Home page.")
 else:
-    df_all = st.session_state['df_all'].copy()
-    numeric_cols = ['Carry', 'Backspin', 'Sidespin', 'Total', 'Smash Factor', 'Apex Height', 'Launch Angle', 'Attack Angle']
+    df_all = st.session_state["df_all"].copy()
+    numeric_cols = [
+        "Carry",
+        "Backspin",
+        "Sidespin",
+        "Total",
+        "Smash Factor",
+        "Apex Height",
+        "Launch Angle",
+        "Attack Angle",
+    ]
 
     for col in numeric_cols:
         if col in df_all.columns:
-            df_all[col] = pd.to_numeric(df_all[col], errors='coerce')
-    df_all = df_all.dropna(subset=['Club'] + numeric_cols, how='any')
+            df_all[col] = pd.to_numeric(df_all[col], errors="coerce")
+    df_all = df_all.dropna(subset=["Club"] + numeric_cols, how="any")
 
-    sessions = st.multiselect("Select Sessions", df_all['Session'].unique(), default=df_all['Session'].unique())
-    clubs = st.multiselect("Select Clubs", df_all['Club'].unique(), default=df_all['Club'].unique())
-    filtered = df_all[df_all['Session'].isin(sessions) & df_all['Club'].isin(clubs)]
+    sessions = st.multiselect("Select Sessions", df_all["Session"].unique(), default=df_all["Session"].unique())
+    clubs = st.multiselect("Select Clubs", df_all["Club"].unique(), default=df_all["Club"].unique())
+    filtered = df_all[df_all["Session"].isin(sessions) & df_all["Club"].isin(clubs)]
 
     if filtered.empty:
         st.info("No data found with the current filters.")
     else:
         st.subheader("✅ Benchmark Comparison Results")
-        grouped = filtered.groupby('Club')[numeric_cols].mean().round(1).reset_index()
+        grouped = filtered.groupby("Club")[numeric_cols].mean().round(1).reset_index()
 
         cols = st.columns(3)
         for idx, row in grouped.iterrows():
             with cols[idx % 3]:
-                club_name = row['Club']
+                club_name = row["Club"]
                 st.markdown(f"### {club_name}")
                 result_lines = check_benchmark(club_name, row)
                 for line in result_lines:
                     st.write(f"- {line}")
 
         st.markdown("---")
-        st.markdown("This report compares your club performance against Jon Sherman–inspired benchmarks for mid-handicap players. Use ✅ and ❌ to focus your practice on key weaknesses.")
+        st.markdown(
+            "This report compares your club performance against Jon Sherman–inspired benchmarks for mid-handicap players. Use ✅ and ❌ to focus your practice on key weaknesses."
+        )

--- a/utils/sidebar.py
+++ b/utils/sidebar.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+
+def render_sidebar() -> None:
+    """Render navigation links in the sidebar for all pages."""
+    st.sidebar.title("Navigation")
+    st.sidebar.page_link("app.py", label="🏠 Home")
+    st.sidebar.page_link("pages/0_Dashboard.py", label="📊 Club Dashboard")
+    st.sidebar.page_link("pages/1_Sessions_Viewer.py", label="📋 Sessions Viewer")
+    st.sidebar.page_link("pages/2_Benchmark_Report.py", label="📌 Benchmark Report")


### PR DESCRIPTION
## Summary
- add shared `render_sidebar` helper with page links to Home, Club Dashboard, Sessions Viewer, and Benchmark Report
- invoke `render_sidebar` across `app.py` and all page modules for consistent navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef045933c83308617cc2cd889e7ac