### PR TITLE
Fix club-based launch angle highlighting in dashboard

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -117,9 +117,16 @@ else:
             return ['background-color: red' if v < 1.3 else 'background-color: green' for v in s]
         elif s.name == 'Launch Angle_mean':
             tooltip = "Target: 10-16° (Driver), 15-20° (7 Iron)"
-            return ['background-color: ' + ('red' if any(c in club for club in s.index for c in ['Driver']) and (v < 10 or v > 16) else 
-                                          'red' if any(c in club for club in s.index for c in ['7 Iron', 'Iron']) and (v < 15 or v > 20) else 
-                                          'green') for v, club in zip(s, s.index)]
+            clubs = grouped_flat.loc[s.index, 'Club']
+            styles = []
+            for v, club in zip(s, clubs):
+                if 'Driver' in club:
+                    styles.append('background-color: red' if (v < 10 or v > 16) else 'background-color: green')
+                elif '7 Iron' in club or 'Iron' in club:
+                    styles.append('background-color: red' if (v < 15 or v > 20) else 'background-color: green')
+                else:
+                    styles.append('background-color: green')
+            return styles
         elif s.name == 'Apex Height_mean':
             tooltip = "Target: 30-40 ft (Driver), 60-90 ft (Irons)"
             return ['background-color: red' if v < 30 or v > 40 else 'background-color: green' for v in s]


### PR DESCRIPTION
## Summary
- Refactor highlight_metrics to use club names when styling launch angle metrics
- Prevent TypeError when checking for club types and ensure driver and iron rows are evaluated correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef31f25d48330a57955107556aeba