### PR TITLE
Add wedge launch and spin drill recommendations

### DIFF
--- a/test_drill_recommendations.py
+++ b/test_drill_recommendations.py
@@ -48,3 +48,28 @@ def test_poor_launch_angle():
     recs = recommend_drills(df)
     issues = [r.issue for r in recs['7 Iron']]
     assert "Poor launch angle" in issues
+
+
+def test_high_launch_wedge():
+    df = pd.DataFrame({
+        'Club Type': ['PW', 'PW'],
+        'Carry Distance': [100, 101],
+        'Smash Factor': [1.26, 1.27],
+        'Launch Angle': [45, 46],
+    })
+    recs = recommend_drills(df)
+    issues = [r.issue for r in recs['PW']]
+    assert "Launch angle too high with wedge" in issues
+
+
+def test_excessive_wedge_backspin():
+    df = pd.DataFrame({
+        'Club Type': ['PW', 'PW'],
+        'Carry Distance': [100, 102],
+        'Smash Factor': [1.26, 1.27],
+        'Launch Angle': [30, 31],
+        'Backspin': [12000, 12500],
+    })
+    recs = recommend_drills(df)
+    issues = [r.issue for r in recs['PW']]
+    assert "Excessive wedge backspin" in issues


### PR DESCRIPTION
## Summary
- Recommend specific drills when wedges show excessive launch angle or backspin.
- Detect wedge clubs and flag high launch angles (>40°) and spin above benchmark thresholds.
- Add unit tests for wedge launch and backspin scenarios.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef443fd4483309b97f202abd44b11