### PR TITLE
Add practice log Streamlit page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ A Streamlit-based app for analyzing and improving your golf performance using da
 - Per-club report cards with ✅ / ❌ ratings
 - Built-in feedback for practice priorities
 
+### 📝 Practice Log (NEW)
+- Track session notes and completed drills
+- Save logs locally and download as CSV
+
 ### 🧠 AI Insights (Optional)
 - Requires `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` environment variables
 - Generates coaching-style analysis and per-club summaries

--- a/pages/3_Practice_Log.py
+++ b/pages/3_Practice_Log.py
@@ -1,0 +1,53 @@
+import streamlit as st
+import pandas as pd
+import os
+from datetime import date
+
+from utils.sidebar import render_sidebar
+from utils.drill_recommendations import _DRILLS
+
+st.set_page_config(layout="centered")
+st.header("📝 Practice Log")
+
+render_sidebar()
+
+PRACTICE_LOG_FILE = "practice_log.csv"
+
+# Prepare available drills from recommendations
+AVAILABLE_DRILLS = [rec.drill for rec in _DRILLS.values()]
+
+# Load existing practice log if available
+if os.path.exists(PRACTICE_LOG_FILE):
+    log_df = pd.read_csv(PRACTICE_LOG_FILE)
+else:
+    log_df = pd.DataFrame(columns=["Date", "Notes", "Drills Completed"])
+
+st.subheader("Log a Practice Session")
+with st.form("practice_form"):
+    session_date = st.date_input("Date", value=date.today())
+    notes = st.text_area("Notes")
+    st.markdown("#### Drills")
+    drill_checks = {drill: st.checkbox(drill) for drill in AVAILABLE_DRILLS}
+    submitted = st.form_submit_button("Save Session")
+
+    if submitted:
+        completed = [drill for drill, done in drill_checks.items() if done]
+        new_row = {
+            "Date": session_date.isoformat(),
+            "Notes": notes,
+            "Drills Completed": ", ".join(completed),
+        }
+        log_df = pd.concat([log_df, pd.DataFrame([new_row])], ignore_index=True)
+        try:
+            log_df.to_csv(PRACTICE_LOG_FILE, index=False)
+            st.success("Session saved")
+        except Exception as e:
+            st.error(f"Failed to save session: {e}")
+
+if not log_df.empty:
+    st.subheader("Practice History")
+    st.dataframe(log_df, use_container_width=True)
+    csv = log_df.to_csv(index=False).encode("utf-8")
+    st.download_button("Download CSV", csv, "practice_log.csv", "text/csv")
+else:
+    st.info("No practice sessions logged yet.")

--- a/utils/sidebar.py
+++ b/utils/sidebar.py
@@ -12,3 +12,4 @@ def render_sidebar() -> None:
     st.sidebar.page_link("pages/0_Dashboard.py", label="📊 Club Dashboard")
     st.sidebar.page_link("pages/1_Sessions_Viewer.py", label="📋 Sessions Viewer")
     st.sidebar.page_link("pages/2_Benchmark_Report.py", label="📌 Benchmark Report")
+    st.sidebar.page_link("pages/3_Practice_Log.py", label="📝 Practice Log")


### PR DESCRIPTION
## Summary
- add Streamlit page for logging practice sessions and checking off drills
- link practice log in sidebar navigation
- document practice log feature in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ef48ea9c483309cff5b195af0c32f