### PR TITLE
refactor: share AI summary helper

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -6,6 +6,7 @@ import plotly.express as px
 import os
 
 from utils.sidebar import render_sidebar
+from utils.ai_feedback import generate_ai_summary
 
 st.set_page_config(layout="centered")
 st.header("📊 Dashboard – Club Summary")
@@ -202,59 +203,6 @@ else:
     show_ai_feedback = st.checkbox("\U0001F4A1 Show AI Summary Under Each Club", value=False)
     if show_ai_feedback:
         st.info("Generating personalized feedback per club based on your session data...")
-
-    api_key = os.getenv("OPENAI_API_KEY")
-    assistant_id = os.getenv("OPENAI_ASSISTANT_ID")
-    client = openai.OpenAI(api_key=api_key) if api_key else None
-
-    def generate_ai_summary(club_name, df):
-        shots = df[df["Club"] == club_name]
-        if shots.empty:
-            return "No data for this club."
-
-        carry = shots["Carry"].mean()
-        smash = shots["Smash Factor"].mean()
-        launch = shots["Launch Angle"].mean()
-        backspin = shots["Backspin"].mean()
-        std_dev = shots["Carry"].std()
-        shot_count = len(shots)
-
-        prompt = f"""
-You're a golf performance coach trained in Jon Sherman's Four Foundations. I use a Garmin R10. Give me a short, actionable summary for my {club_name} based on these stats:
-
-- Carry: {carry:.1f} yds
-- Smash: {smash:.2f}
-- Launch: {launch:.1f}°
-- Backspin: {backspin:.0f} rpm
-- Std Dev (Carry): {std_dev:.1f}
-- Shots: {shot_count}
-
-Explain what this means for my consistency and what to do in practice. Be specific and encouraging. Mention if anything is a standout or weak point.
-"""
-
-        if not client or not assistant_id:
-            return "⚠️ AI credentials missing."
-        try:
-            thread = client.beta.threads.create()
-            client.beta.threads.messages.create(
-                thread_id=thread.id,
-                role="user",
-                content=prompt
-            )
-            run = client.beta.threads.runs.create(
-                thread_id=thread.id,
-                assistant_id=assistant_id
-            )
-            import time
-            while run.status not in ["completed", "failed", "cancelled", "expired"]:
-                time.sleep(1)
-                run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
-            if run.status == "completed":
-                messages = client.beta.threads.messages.list(thread_id=thread.id)
-                return messages.data[0].content[0].text.value
-            return f"⚠️ AI summary error: {run.status}"
-        except Exception as e:
-            return f"⚠️ AI summary error: {str(e)}"
 
     for club in sorted(filtered["Club"].unique()):
         st.subheader(f"\U0001F50E {club}")

--- a/pages/2_Benchmark_Report.py
+++ b/pages/2_Benchmark_Report.py
@@ -3,6 +3,7 @@ import pandas as pd
 from utils.benchmarks import check_benchmark
 
 from utils.sidebar import render_sidebar
+from utils.ai_feedback import generate_ai_summary
 
 st.set_page_config(layout="centered")
 st.header("📌 Benchmark Report – Club Performance vs. Goals")
@@ -37,6 +38,10 @@ else:
         st.info("No data found with the current filters.")
     else:
         st.subheader("✅ Benchmark Comparison Results")
+        show_ai_feedback = st.checkbox("\U0001F4A1 Show AI Summary Under Each Club", value=False)
+        if show_ai_feedback:
+            st.info("Generating personalized feedback per club based on your session data...")
+
         grouped = filtered.groupby("Club")[numeric_cols].mean().round(1).reset_index()
 
         cols = st.columns(3)
@@ -47,6 +52,10 @@ else:
                 result_lines = check_benchmark(club_name, row)
                 for line in result_lines:
                     st.write(f"- {line}")
+                if show_ai_feedback:
+                    with st.spinner(f"Analyzing {club_name}..."):
+                        feedback = generate_ai_summary(club_name, filtered)
+                        st.markdown(f"**AI Feedback:**\n\n> {feedback}")
 
         st.markdown("---")
         st.markdown(

--- a/utils/ai_feedback.py
+++ b/utils/ai_feedback.py
@@ -1,0 +1,58 @@
+# ai_feedback.py
+
+import os
+import openai
+
+
+def generate_ai_summary(club_name, df):
+    shots = df[df["Club"] == club_name]
+    if shots.empty:
+        return "No data for this club."
+
+    carry = shots["Carry"].mean()
+    smash = shots["Smash Factor"].mean()
+    launch = shots["Launch Angle"].mean()
+    backspin = shots["Backspin"].mean()
+    std_dev = shots["Carry"].std()
+    shot_count = len(shots)
+
+    prompt = f"""
+You're a golf performance coach trained in Jon Sherman's Four Foundations. I use a Garmin R10. Give me a short, actionable summary for my {club_name} based on these stats:
+
+- Carry: {carry:.1f} yds
+- Smash: {smash:.2f}
+- Launch: {launch:.1f}°
+- Backspin: {backspin:.0f} rpm
+- Std Dev (Carry): {std_dev:.1f}
+- Shots: {shot_count}
+
+Explain what this means for my consistency and what to do in practice. Be specific and encouraging. Mention if anything is a standout or weak point.
+"""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    assistant_id = os.getenv("OPENAI_ASSISTANT_ID")
+    client = openai.OpenAI(api_key=api_key) if api_key else None
+
+    if not client or not assistant_id:
+        return "⚠️ AI credentials missing."
+    try:
+        thread = client.beta.threads.create()
+        client.beta.threads.messages.create(
+            thread_id=thread.id,
+            role="user",
+            content=prompt,
+        )
+        run = client.beta.threads.runs.create(
+            thread_id=thread.id,
+            assistant_id=assistant_id,
+        )
+        import time
+        while run.status not in ["completed", "failed", "cancelled", "expired"]:
+            time.sleep(1)
+            run = client.beta.threads.runs.retrieve(thread_id=thread.id, run_id=run.id)
+        if run.status == "completed":
+            messages = client.beta.threads.messages.list(thread_id=thread.id)
+            return messages.data[0].content[0].text.value
+        return f"⚠️ AI summary error: {run.status}"
+    except Exception as e:
+        return f"⚠️ AI summary error: {str(e)}"


### PR DESCRIPTION
## Summary
- centralize generate_ai_summary in utils/ai_feedback.py
- reuse helper for optional per-club AI summaries on Dashboard and Benchmark pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ef4a2347083308b8adc2acdf547dc