### PR TITLE
Improve CSV error handling with preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,14 +97,15 @@ else:
                     dfs.append(df)
                     total_rows += len(df)
                     st.progress((idx + 1) / len(uploaded_files))
-                except pd.errors.ParserError:
-                    st.error(
-                        f"Error processing {file.name}: Malformed CSV. File skipped."
-                    )
                 except Exception as e:
-                    st.error(
-                        f"Error processing {file.name}: {str(e)}. File skipped. Check if it's a valid CSV."
+                    file.seek(0)
+                    preview_lines = (
+                        file.getvalue().decode('utf-8', errors='replace').splitlines()[:10]
                     )
+                    preview_text = '\n'.join(preview_lines)
+                    st.error(f"Failed to process {file.name}: {e}")
+                    st.text("First 10 lines of the file for debugging:")
+                    st.code(preview_text)
             
             if not dfs:
                 st.error("No valid CSVs loaded. Please check your files and try again.")

--- a/pages/3_Practice_Log.py
+++ b/pages/3_Practice_Log.py
@@ -18,7 +18,21 @@ AVAILABLE_DRILLS = [rec.drill for rec in _DRILLS.values()]
 
 # Load existing practice log if available
 if os.path.exists(PRACTICE_LOG_FILE):
-    log_df = pd.read_csv(PRACTICE_LOG_FILE)
+    try:
+        log_df = pd.read_csv(PRACTICE_LOG_FILE)
+    except Exception as e:
+        st.error(f"Failed to load practice log: {e}")
+        try:
+            with open(
+                PRACTICE_LOG_FILE, "r", encoding="utf-8", errors="replace"
+            ) as f:
+                preview_lines = [next(f, "") for _ in range(10)]
+            preview_text = "".join(preview_lines)
+            st.text("First 10 lines of the practice log file:")
+            st.code(preview_text)
+        except Exception:
+            pass
+        log_df = pd.DataFrame(columns=["Date", "Notes", "Drills Completed"])
 else:
     log_df = pd.DataFrame(columns=["Date", "Notes", "Drills Completed"])
 


### PR DESCRIPTION
## Summary
- show first 10 lines of a CSV file when parsing fails
- guard practice log loading with error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688efaddd49c8330b65183154073b01b