### PR TITLE
Ensure clean Docker builds by disabling cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY . .
-
+# Copy only requirements first to leverage Docker layer caching and
+# avoid potential lease issues when installing dependencies.
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code in a separate step.
+COPY . .
 
 EXPOSE 8501
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
+### 🐳 Docker Build (Optional)
+
+If you prefer to run the app in a container, build the image with Docker's
+cache disabled to avoid occasional `lease <id>: not found` errors from
+BuildKit:
+
+```bash
+./build.sh
+```
+
+This script wraps `docker build --no-cache` so no cached layers are reused
+during the build.
+
 ### ☁️ Deploy to Render
 1. Add `PASSWORD` as environment variable
 2. Deploy using `render.yaml` + Dockerfile

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build the Docker image without using cache to avoid BuildKit lease errors.
+docker build --no-cache -t garmin-r10-analyzer .


### PR DESCRIPTION
## Summary
- Split Dockerfile steps so dependencies are installed before the app code and reduce cache-related lease errors.
- Add build.sh script to build the Docker image with `--no-cache`.
- Document non-cached Docker builds in the README.

## Testing
- `pytest`
- `./build.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688efc2f2d988330a1631b6328116ab0