### PR TITLE
Ensure uploaded session data is accessible across Streamlit pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from utils.logger import logger
+from utils.session_loader import load_sessions
 
 st.set_page_config(page_title="Garmin R10 Analyzer", layout="wide")
 st.title("📊 Garmin R10 Analyzer")
@@ -18,6 +19,17 @@ if uploaded_files:
     # Store newly uploaded files in session state
     st.session_state["uploaded_files"] = uploaded_files
     logger.info(f"{len(uploaded_files)} files uploaded and stored in session state")
+
+    # Load and persist session data for use across pages
+    df = load_sessions(uploaded_files)
+    if not df.empty:
+        st.session_state["session_df"] = df
+        st.session_state["df_all"] = df
+        if "Club" in df.columns:
+            st.session_state["club_data"] = {club: grp for club, grp in df.groupby("Club")}
+        else:
+            st.session_state["club_data"] = {}
+
     st.success(f"✅ {len(uploaded_files)} file(s) uploaded. Navigate to any page to begin.")
 elif st.session_state["uploaded_files"]:
     # Inform the user that files are already stored
@@ -32,4 +44,7 @@ else:
 if st.session_state["uploaded_files"]:
     if st.button("Clear uploaded files"):
         st.session_state.pop("uploaded_files", None)
+        st.session_state.pop("session_df", None)
+        st.session_state.pop("df_all", None)
+        st.session_state.pop("club_data", None)
         st.experimental_rerun()

--- a/pages/5_AI_Practice_Summary.py
+++ b/pages/5_AI_Practice_Summary.py
@@ -1,36 +1,29 @@
 import streamlit as st
 from utils.logger import logger
+
 uploaded_files = st.session_state.get("uploaded_files", [])
 if not uploaded_files:
     st.warning("📤 Please upload CSV files on the home page first.")
     st.stop()
 
-import pandas as pd
-from utils.session_loader import load_sessions
 from utils.practice_ai import analyze_practice_session
-from utils.logger import logger
 
 st.title("🧠 AI Practice Summary")
 
-uploaded_files = st.file_uploader("Upload Garmin CSV file(s)", type=["csv"], accept_multiple_files=True)
+df = st.session_state.get("session_df")
 
-if uploaded_files:
-    df = load_sessions(uploaded_files)
+if df is not None and not df.empty:
+    logger.info("Analyzing session with AI practice engine")
+    results = analyze_practice_session(df)
 
-    if df is not None and not df.empty:
-        logger.info("Analyzing session with AI practice engine")
-        results = analyze_practice_session(df)
-
-        for entry in results:
-            st.subheader(f"📌 {entry['club']}")
-            st.markdown("**AI Summary:**")
-            st.info(entry["summary"])
-            if entry["issues"]:
-                st.markdown("**Detected Issues:**")
-                for issue in entry["issues"]:
-                    st.write(f"- {issue}")
-            st.markdown("---")
-    else:
-        st.error("⚠️ Unable to parse data from uploaded file(s).")
+    for entry in results:
+        st.subheader(f"📌 {entry['club']}")
+        st.markdown("**AI Summary:**")
+        st.info(entry["summary"])
+        if entry["issues"]:
+            st.markdown("**Detected Issues:**")
+            for issue in entry["issues"]:
+                st.write(f"- {issue}")
+        st.markdown("---")
 else:
-    st.warning("📤 Upload one or more Garmin CSV files to begin.")
+    st.error("⚠️ Unable to parse data from uploaded file(s).")


### PR DESCRIPTION
## Summary
- Persist uploaded CSV data as processed DataFrames in `st.session_state` so that all pages can use the same session data.
- Simplify AI Practice Summary page to use shared session data instead of its own uploader.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9f3b20f883308f65fb74e3efabbe