### PR TITLE
Fix dashboard df error and support 'Club Type' column

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -1,15 +1,15 @@
 import streamlit as st
 from utils.logger import logger
+import pandas as pd
+import plotly.express as px
+import numpy as np
+
 uploaded_files = st.session_state.get("uploaded_files", [])
 if not uploaded_files:
     st.warning("📤 Please upload CSV files on the home page first.")
     st.stop()
 
-from utils.logger import logger
 logger.info("📄 Page loaded: 0 Dashboard")
-import pandas as pd
-import plotly.express as px
-import numpy as np
 
 st.title("📊 Club Performance Dashboard")
 
@@ -18,16 +18,21 @@ if "session_df" not in st.session_state or st.session_state["session_df"].empty:
     st.info("Please upload session files from the Home page to view this dashboard.")
     st.stop()
 
-club_data = st.session_state["club_data"]
+df = st.session_state["session_df"].copy()
+
+# Ensure a consistent club column name
 if "Club" not in df.columns:
-    st.error("❌ The uploaded data does not contain a 'Club' column. Please check your CSV files.")
-    st.stop()
+    if "Club Type" in df.columns:
+        df["Club"] = df["Club Type"]
+    else:
+        st.error("❌ The uploaded data does not contain a 'Club' column. Please check your CSV files.")
+        st.stop()
 
 # Sidebar club selection
-club_list = sorted(club_data.keys().dropna().unique())
+club_list = sorted(df["Club"].dropna().unique())
 selected_club = st.sidebar.selectbox("Select a club to view", club_list)
 
-club_data = df[club_data.keys() == selected_club]
+club_data = df[df["Club"] == selected_club]
 
 # Show basic stats
 st.subheader(f"Stats for {selected_club}")
@@ -36,10 +41,11 @@ st.write(club_data.describe(include='all'))
 # Plot carry distance distribution
 if "Carry" in club_data.columns:
     st.plotly_chart(px.histogram(club_data, x="Carry", nbins=20, title="Carry Distance Distribution"))
+elif "Carry Distance" in club_data.columns:
+    st.plotly_chart(px.histogram(club_data, x="Carry Distance", nbins=20, title="Carry Distance Distribution"))
 
 # Launch angle and smash factor scatter plot
 if "Launch Angle" in club_data.columns and "Smash Factor" in club_data.columns:
     st.plotly_chart(
-        px.scatter(club_data, x="Launch Angle", y="Smash Factor", 
-                   title="Launch Angle vs Smash Factor", trendline="ols")
+        px.scatter(club_data, x="Launch Angle", y="Smash Factor", title="Launch Angle vs Smash Factor", trendline="ols")
     )

--- a/utils/session_loader.py
+++ b/utils/session_loader.py
@@ -8,6 +8,9 @@ def load_sessions(files):
             content = file.getvalue().decode("utf-8")
             df = pd.read_csv(io.StringIO(content))
             df["Session Name"] = file.name
+            # Normalise club column name
+            if "Club" not in df.columns and "Club Type" in df.columns:
+                df["Club"] = df["Club Type"]
             dfs.append(df)
         except Exception as e:
             print(f"Failed to load {file.name}: {e}")


### PR DESCRIPTION
## Summary
- Normalize "Club Type" to "Club" during session loading
- Refactor dashboard to use session DataFrame, including club column fallback and carry distance support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb3b24b108330a47e52e53b020614