### PR TITLE
Normalize column names for sample data

### DIFF
--- a/pages/2_Benchmark_Report.py
+++ b/pages/2_Benchmark_Report.py
@@ -29,9 +29,13 @@ def compare_to_benchmark(club, club_df):
         return result
 
     for metric, target in bmark.items():
-        if metric not in club_df.columns:
-            continue
-        value = pd.to_numeric(club_df[metric], errors="coerce").mean()
+        col = metric
+        if col not in club_df.columns:
+            if metric == "Carry" and "Carry Distance" in club_df.columns:
+                col = "Carry Distance"
+            else:
+                continue
+        value = pd.to_numeric(club_df[col], errors="coerce").mean()
         if isinstance(target, tuple):
             result[metric] = "✅" if target[0] <= value <= target[1] else "❌"
         else:

--- a/utils/ai_feedback.py
+++ b/utils/ai_feedback.py
@@ -10,11 +10,12 @@ def generate_ai_summary(club_name, df):
     if shots.empty:
         return "No data for this club."
 
-    carry = shots["Carry"].mean()
+    carry_col = "Carry Distance" if "Carry Distance" in shots.columns else "Carry"
+    carry = shots[carry_col].mean()
     smash = shots["Smash Factor"].mean()
     launch = shots["Launch Angle"].mean()
     backspin = shots["Backspin"].mean()
-    std_dev = shots["Carry"].std()
+    std_dev = shots[carry_col].std()
     shot_count = len(shots)
 
     prompt = f"""
@@ -93,11 +94,12 @@ def generate_ai_batch_summaries(df) -> Dict[str, str]:
         shots = df[df["Club"] == club]
         if shots.empty:
             continue
-        carry = shots["Carry"].mean()
+        carry_col = "Carry Distance" if "Carry Distance" in shots.columns else "Carry"
+        carry = shots[carry_col].mean()
         smash = shots["Smash Factor"].mean()
         launch = shots["Launch Angle"].mean()
         backspin = shots["Backspin"].mean()
-        std_dev = shots["Carry"].std()
+        std_dev = shots[carry_col].std()
         shot_count = len(shots)
         section = (
             f"{club}\n"

--- a/utils/practice_ai.py
+++ b/utils/practice_ai.py
@@ -12,18 +12,23 @@ def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
     if club_df.empty:
         return {"club": club, "issues": ["No data"], "summary": "No data available."}
 
-    # Clean and cast
+    # Clean and cast existing columns only
     for col in ["Carry Distance", "Launch Angle", "Spin Rate", "Smash Factor", "Offline"]:
-        club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
+        if col in club_df.columns:
+            club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
 
-    avg_smash = club_df["Smash Factor"].mean()
-    avg_launch = club_df["Launch Angle"].mean()
-    avg_spin = club_df["Spin Rate"].mean()
-    avg_carry = club_df["Carry Distance"].mean()
-    avg_offline = club_df["Offline"].mean()
-    std_carry = club_df["Carry Distance"].std()
-    left_bias = (club_df["Offline"] < 0).mean() * 100
-    right_bias = (club_df["Offline"] > 0).mean() * 100
+    avg_smash = club_df["Smash Factor"].mean() if "Smash Factor" in club_df else np.nan
+    avg_launch = club_df["Launch Angle"].mean() if "Launch Angle" in club_df else np.nan
+    avg_spin = club_df["Spin Rate"].mean() if "Spin Rate" in club_df else np.nan
+    avg_carry = club_df["Carry Distance"].mean() if "Carry Distance" in club_df else np.nan
+    avg_offline = club_df["Offline"].mean() if "Offline" in club_df else np.nan
+    std_carry = club_df["Carry Distance"].std() if "Carry Distance" in club_df else np.nan
+    left_bias = (
+        (club_df["Offline"] < 0).mean() * 100 if "Offline" in club_df else 0
+    )
+    right_bias = (
+        (club_df["Offline"] > 0).mean() * 100 if "Offline" in club_df else 0
+    )
 
     # Rules
     if avg_smash < 1.2:


### PR DESCRIPTION
## Summary
- Allow AI feedback and benchmark report to use `Carry Distance` when `Carry` is absent
- Guard practice AI against missing optional columns like `Spin Rate` and `Offline`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb8438b7c83309ef633cbef19b8ab