### PR TITLE
Improve type safety for Garmin data processing

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -105,19 +105,11 @@ smash_factor = (
 total_shots = len(df_filtered)
 
 if "Face Impact Location" in df_filtered.columns:
-    center_strike_pct = (
-        df_filtered["Face Impact Location"].str.contains(
-            "center", case=False, na=False
-        ).mean()
-        * 100
-    )
+    col = df_filtered["Face Impact Location"].astype(str)
+    center_strike_pct = col.str.contains("center", case=False, na=False).mean() * 100
 elif "Club Face Contact" in df_filtered.columns:
-    center_strike_pct = (
-        df_filtered["Club Face Contact"].str.contains(
-            "center", case=False, na=False
-        ).mean()
-        * 100
-    )
+    col = df_filtered["Club Face Contact"].astype(str)
+    center_strike_pct = col.str.contains("center", case=False, na=False).mean() * 100
 else:
     center_strike_pct = np.nan
 

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -62,13 +62,23 @@ def check_benchmark(club_name, stats):
 
     for metric, threshold in benchmarks[target_type].items():
         user_val = stats.get(metric)
-        if user_val is None:
+        # ``stats`` may contain strings or other non-numeric values. Attempt to
+        # coerce to ``float`` and skip the metric entirely if that fails so we
+        # don't raise ``TypeError`` when formatting or comparing.
+        try:
+            user_val = float(user_val)
+        except (TypeError, ValueError):
             continue
+
         if isinstance(threshold, tuple):
             low, high = threshold
             symbol = "✅" if low <= user_val <= high else "❌"
-            result_lines.append(f"{metric}: {symbol} (You: {user_val:.1f}, Target: {low}–{high})")
+            result_lines.append(
+                f"{metric}: {symbol} (You: {user_val:.1f}, Target: {low}–{high})"
+            )
         else:
             symbol = "✅" if user_val >= threshold else "❌"
-            result_lines.append(f"{metric}: {symbol} (You: {user_val:.1f}, Target: ≥{threshold})")
+            result_lines.append(
+                f"{metric}: {symbol} (You: {user_val:.1f}, Target: ≥{threshold})"
+            )
     return result_lines

--- a/utils/practice_ai.py
+++ b/utils/practice_ai.py
@@ -89,6 +89,10 @@ def summarize_with_ai(club: str, issues: list[str]) -> str:
 
 def analyze_practice_session(df: pd.DataFrame) -> list[dict]:
     """Generate practice feedback for each club in ``df``."""
-
+    # ``df`` may come from arbitrary CSVs.  Guard against the ``Club`` column
+    # being missing to avoid ``KeyError``s when the caller supplies malformed
+    # data.
+    if "Club" not in df.columns:
+        return []
     clubs = df["Club"].dropna().unique()
     return [analyze_club_stats(df, club) for club in clubs]

--- a/utils/session_loader.py
+++ b/utils/session_loader.py
@@ -15,15 +15,33 @@ def load_sessions(files):
     dfs = []
     for file in files:
         try:
-            content = file.getvalue().decode("utf-8")
+            # ``UploadedFile`` objects from Streamlit expose ``getvalue``.
+            # Fallback to ``read`` for generic file objects.  Accept both bytes
+            # and text input, attempting UTF-8 decoding first and falling back to
+            # latin-1 so unusual encodings don't immediately raise errors.
+            if hasattr(file, "getvalue"):
+                raw = file.getvalue()
+            elif hasattr(file, "read"):
+                raw = file.read()
+            else:
+                raise AttributeError("File object has no read() method")
+
+            if isinstance(raw, bytes):
+                try:
+                    content = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    content = raw.decode("latin-1")
+            else:
+                content = str(raw)
+
             df = pd.read_csv(io.StringIO(content))
-            df["Session Name"] = file.name
+            df["Session Name"] = getattr(file, "name", "Unknown")
             # Normalise club column name
             if "Club" not in df.columns and "Club Type" in df.columns:
                 df["Club"] = df["Club Type"]
             dfs.append(df)
         except Exception as e:
-            print(f"Failed to load {file.name}: {e}")
+            print(f"Failed to load {getattr(file, 'name', 'unknown')}: {e}")
     if dfs:
         return pd.concat(dfs, ignore_index=True)
     return pd.DataFrame()


### PR DESCRIPTION
## Summary
- Avoid type errors in benchmark comparisons by coercing non-numeric stats
- Harden drill recommendations and AI feedback against missing or string data
- Prevent crashes when session files or DataFrame columns are missing or oddly typed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fcfb160348330a27176c917555aef