### PR TITLE
fix: handle non-numeric metric values across pages

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -89,6 +89,11 @@ club_list = sorted(df_filtered["Club"].dropna().unique())
 # Display key metrics for the filtered sessions
 st.subheader("Key Metrics")
 
+# Guard against non-numeric strings in metric columns
+for col in ["Carry Distance", "Carry", "Smash Factor"]:
+    if col in df_filtered.columns:
+        df_filtered[col] = pd.to_numeric(df_filtered[col], errors="coerce")
+
 if "Carry Distance" in df_filtered.columns:
     avg_carry = df_filtered["Carry Distance"].mean()
 elif "Carry" in df_filtered.columns:

--- a/pages/2_Benchmark_Report.py
+++ b/pages/2_Benchmark_Report.py
@@ -30,12 +30,16 @@ benchmarks = get_benchmarks()
 
 def compare_to_benchmark(club, club_df):
     result = {"Club": club}
-    club_stats = club_df.describe().T
 
     bmark = benchmarks.get(club)
     if not bmark:
         result["Note"] = "No benchmark available"
         return result
+
+    club_df = club_df.copy()
+    for col in ["Carry Distance", "Carry", "Smash Factor", "Launch Angle", "Backspin"]:
+        if col in club_df.columns:
+            club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
 
     for metric, target in bmark.items():
         col = metric
@@ -44,7 +48,7 @@ def compare_to_benchmark(club, club_df):
                 col = "Carry Distance"
             else:
                 continue
-        value = pd.to_numeric(club_df[col], errors="coerce").mean()
+        value = club_df[col].mean()
         if isinstance(target, tuple):
             result[metric] = "✅" if target[0] <= value <= target[1] else "❌"
         else:

--- a/pages/4_AI_Insights.py
+++ b/pages/4_AI_Insights.py
@@ -18,7 +18,10 @@ if "session_df" not in st.session_state or st.session_state["session_df"].empty:
     st.info("Please upload session files from the Home page.")
     st.stop()
 
-df = st.session_state["session_df"]
+df = st.session_state["session_df"].copy()
+for col in ["Carry Distance", "Carry", "Smash Factor", "Launch Angle", "Backspin"]:
+    if col in df.columns:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
 club_list = sorted(df["Club"].dropna().unique())
 selected_club = st.selectbox("Select a club for feedback", club_list)
 

--- a/pages/5_AI_Practice_Summary.py
+++ b/pages/5_AI_Practice_Summary.py
@@ -15,6 +15,18 @@ st.title("🧠 AI Practice Summary")
 df = st.session_state.get("session_df")
 
 if df is not None and not df.empty:
+    df = df.copy()
+    for col in [
+        "Carry Distance",
+        "Carry",
+        "Smash Factor",
+        "Launch Angle",
+        "Backspin",
+        "Spin Rate",
+        "Offline",
+    ]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
     logger.info("Analyzing session with AI practice engine")
     results = analyze_practice_session(df)
 


### PR DESCRIPTION
## Summary
- prevent Benchmark Report from failing on string-filled metrics by coercing key columns to numeric before averaging
- sanitize shot metrics on AI Insights and AI Practice Summary pages prior to generating summaries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd85061208330b32dd25dc087efad