### PR TITLE
Fix pandas imports in AI pages

### DIFF
--- a/pages/4_AI_Insights.py
+++ b/pages/4_AI_Insights.py
@@ -10,6 +10,7 @@ if not uploaded_files:
 
 logger.info("📄 Page loaded: 4 AI Insights")
 
+import pandas as pd
 from utils.ai_feedback import generate_ai_summary
 
 st.title("🧠 AI Insights")

--- a/pages/5_AI_Practice_Summary.py
+++ b/pages/5_AI_Practice_Summary.py
@@ -8,6 +8,7 @@ if not uploaded_files:
     st.warning("📤 Please upload CSV files on the home page first.")
     st.stop()
 
+import pandas as pd
 from utils.practice_ai import analyze_practice_session
 
 st.title("🧠 AI Practice Summary")


### PR DESCRIPTION
## Summary
- import pandas in AI insights page
- import pandas in AI practice summary page to enable numeric conversions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fdd326d788330aab1a4955e05db06