### PR TITLE
Add club performance summary dashboard

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -1,283 +1,127 @@
-"""Dashboard page showing key metrics, session filters and club statistics.
+"""High-level club performance dashboard.
 
-The dashboard expects session data to already be loaded into Streamlit's
-session state by ``app.py``. Users can filter sessions, view aggregate
-metrics, and drill into club-level statistics with Plotly visualisations.
+This page summarises a golfer's performance across all clubs. Users can
+select a session, review averages and consistency per club, and view quick
+visualisations. Coach-style notes highlight potential red flags.
 """
 
 import streamlit as st
-from utils.logger import logger
 import pandas as pd
 import plotly.express as px
-import numpy as np
+from utils.logger import logger
 
-uploaded_files = st.session_state.get("uploaded_files", [])
-if not uploaded_files:
+# Ensure session data is available
+if "session_df" not in st.session_state or st.session_state["session_df"].empty:
     st.warning("📤 Please upload CSV files on the home page first.")
     st.stop()
 
 logger.info("📄 Page loaded: 0 Dashboard")
 
-st.title("📊 Club Performance Dashboard")
+st.title("📊 Club Performance Summary")
 
-# Expect session_df to be provided via st.session_state from app.py
-if "session_df" not in st.session_state or st.session_state["session_df"].empty:
-    st.info("Please upload session files from the Home page to view this dashboard.")
-    st.stop()
-
-df_all = st.session_state["session_df"].copy()
-
-# Sidebar options to select which session(s) to analyse
-session_names = df_all["Session Name"].dropna().unique().tolist()
-st.sidebar.markdown("### Session Filters")
-view_option = st.sidebar.selectbox(
-    "Choose sessions to analyze",
-    ["Latest Session", "Last 5 Sessions Combined", "Select Sessions"],
-)
-
-if "Date" in df_all.columns:
-    df_all["Date"] = pd.to_datetime(df_all["Date"], errors="coerce")
-
-if view_option == "Latest Session":
-    if "Date" in df_all.columns and df_all["Date"].notna().any():
-        latest_session = df_all.loc[df_all["Date"].idxmax(), "Session Name"]
-    else:
-        latest_session = session_names[-1]
-    df_filtered = df_all[df_all["Session Name"] == latest_session]
-elif view_option == "Last 5 Sessions Combined":
-    if "Date" in df_all.columns and df_all["Date"].notna().any():
-        session_order = (df_all.drop_duplicates("Session Name").sort_values("Date"))[
-            "Session Name"
-        ].tolist()
-    else:
-        session_order = session_names
-    last_sessions = session_order[-5:]
-    df_filtered = df_all[df_all["Session Name"].isin(last_sessions)]
-else:  # Select Sessions
-    chosen = st.sidebar.multiselect("Select session(s)", session_names)
-    df_filtered = (
-        df_all[df_all["Session Name"].isin(chosen)] if chosen else df_all.iloc[0:0]
-    )
-
-if df_filtered.empty:
-    st.warning("No sessions selected.")
-    st.stop()
-
-df_filtered = df_filtered.copy()
-
-# Ensure a consistent club column name
-if "Club" not in df_filtered.columns:
-    if "Club Type" in df_filtered.columns:
-        df_filtered["Club"] = df_filtered["Club Type"]
-    else:
-        st.error(
-            "❌ The uploaded data does not contain a 'Club' column. Please check your CSV files."
-        )
-        st.stop()
-
-st.sidebar.markdown("### Club Filter")
-club_options = sorted(df_filtered["Club"].dropna().unique())
-selected_clubs = st.sidebar.multiselect(
-    "Select club(s)", club_options, default=club_options
-)
-
-if not selected_clubs:
-    st.warning("No clubs selected.")
-    st.stop()
-
-df_filtered = df_filtered[df_filtered["Club"].isin(selected_clubs)]
-club_list = sorted(df_filtered["Club"].dropna().unique())
-
-# Display key metrics for the filtered sessions
-st.subheader("Key Metrics")
-
-# Guard against non-numeric strings in metric columns
-for col in ["Carry Distance", "Carry", "Smash Factor"]:
-    if col in df_filtered.columns:
-        df_filtered[col] = pd.to_numeric(df_filtered[col], errors="coerce")
-
-if "Carry Distance" in df_filtered.columns:
-    avg_carry = df_filtered["Carry Distance"].mean()
-elif "Carry" in df_filtered.columns:
-    avg_carry = df_filtered["Carry"].mean()
-else:
-    avg_carry = np.nan
-
-smash_factor = (
-    df_filtered["Smash Factor"].mean()
-    if "Smash Factor" in df_filtered.columns
-    else np.nan
-)
-
-total_shots = len(df_filtered)
-
-if "Face Impact Location" in df_filtered.columns:
-    col = df_filtered["Face Impact Location"].astype(str)
-    center_strike_pct = col.str.contains("center", case=False, na=False).mean() * 100
-elif "Club Face Contact" in df_filtered.columns:
-    col = df_filtered["Club Face Contact"].astype(str)
-    center_strike_pct = col.str.contains("center", case=False, na=False).mean() * 100
-else:
-    center_strike_pct = np.nan
-
-col1, col2, col3, col4 = st.columns(4)
-col1.metric(
-    "Average Carry Distance",
-    f"{avg_carry:.1f}" if not np.isnan(avg_carry) else "N/A",
-)
-col2.metric(
-    "Smash Factor",
-    f"{smash_factor:.2f}" if not np.isnan(smash_factor) else "N/A",
-)
-col3.metric("Total Shots", f"{total_shots}")
-col4.metric(
-    "Center Strike %",
-    f"{center_strike_pct:.1f}%" if not np.isnan(center_strike_pct) else "N/A",
-)
-
-# Club category summary grid
-carry_col = "Carry Distance" if "Carry Distance" in df_filtered.columns else "Carry"
-if carry_col in df_filtered.columns:
-    df_filtered[carry_col] = pd.to_numeric(df_filtered[carry_col], errors="coerce")
-if "Smash Factor" in df_filtered.columns:
-    df_filtered["Smash Factor"] = pd.to_numeric(
-        df_filtered["Smash Factor"], errors="coerce"
-    )
-agg_dict = {}
-if carry_col in df_filtered.columns:
-    agg_dict[carry_col] = "mean"
-if "Smash Factor" in df_filtered.columns:
-    agg_dict["Smash Factor"] = "mean"
-grouped = (
-    df_filtered.groupby("Club")
-    .agg(agg_dict)
-    .rename(columns={carry_col: "Avg Carry", "Smash Factor": "Avg Smash"})
-)
-
-
-def categorize_club(club: str) -> str:
-    name = club.lower()
-    if "driver" in name:
-        return "Driver"
-    if any(w in name for w in ["wedge", "pw", "aw", "gw", "sw", "lw"]):
-        return "Wedges"
-    if "putter" in name:
-        return "Putter"
-    return "Irons"
-
-
-grouped["Category"] = grouped.index.map(categorize_club)
-category_emojis = {
-    "Driver": "🏌️",
-    "Irons": "🏌️‍♂️",
-    "Wedges": "⛏️",
-    "Putter": "⛳",
+# Copy and standardise column names
+_df = st.session_state["session_df"].copy()
+col_map = {
+    "Session Name": "session_name",
+    "Club": "club",
+    "Club Type": "club",
+    "Carry Distance": "carry_distance",
+    "Carry": "carry_distance",
+    "Ball Speed": "ball_speed",
+    "Launch Angle": "launch_angle",
+    "Backspin": "spin_rate",
+    "Spin Rate": "spin_rate",
 }
+_df = _df.rename(columns={k: v for k, v in col_map.items() if k in _df.columns})
 
-st.subheader("Club Categories")
-categories = ["Driver", "Irons", "Wedges", "Putter"]
-rows = [categories[i : i + 2] for i in range(0, len(categories), 2)]
-for row in rows:
-    cols = st.columns(2)
-    for col, cat in zip(cols, row):
-        with col:
-            emoji = category_emojis.get(cat, "")
-            st.markdown(f"### {emoji} {cat}")
-            cat_df = grouped[grouped["Category"] == cat]
-            if cat_df.empty:
-                st.write("No data")
-            else:
-                for club, vals in cat_df.iterrows():
-                    carry_val = vals.get("Avg Carry")
-                    smash_val = vals.get("Avg Smash")
-                    carry_text = f"{carry_val:.1f}" if pd.notna(carry_val) else "N/A"
-                    smash_text = f"{smash_val:.2f}" if pd.notna(smash_val) else "N/A"
-                    st.write(f"**{club}** - Carry: {carry_text} | Smash: {smash_text}")
+required_cols = [
+    "session_name",
+    "club",
+    "carry_distance",
+    "ball_speed",
+    "launch_angle",
+    "spin_rate",
+]
+missing = [c for c in required_cols if c not in _df.columns]
+if missing:
+    st.error("❌ Missing required columns: " + ", ".join(missing))
+    st.stop()
 
-# Strike location distribution chart
-if "strike_location" in df_filtered.columns:
-    st.subheader("Strike Location Distribution")
-    strike_counts = (
-        df_filtered["strike_location"].astype(str).str.title().value_counts()
-    )
-    strike_counts = strike_counts.reindex(["Center", "Heel", "Toe"], fill_value=0)
-    strike_df = strike_counts.reset_index()
-    strike_df.columns = ["strike_location", "count"]
-    strike_df["percentage"] = (
-        strike_df["count"] / strike_df["count"].sum() * 100
-        if strike_df["count"].sum() > 0
-        else 0
-    )
-    fig_strike = px.bar(
-        strike_df,
-        x="percentage",
-        y="strike_location",
-        orientation="h",
-        text="percentage",
-        custom_data=["count"],
-        labels={"percentage": "Percentage", "strike_location": "Strike Location"},
-    )
-    fig_strike.update_traces(
-        texttemplate="%{x:.1f}%",
-        hovertemplate="%{y}: %{x:.1f}% (%{customdata[0]} shots)<extra></extra>",
-    )
-    fig_strike.update_layout(xaxis=dict(ticksuffix="%"))
-    st.plotly_chart(fig_strike, use_container_width=True)
-else:
-    st.info("No strike location data available.")
+# Convert numeric columns
+for col in ["carry_distance", "ball_speed", "launch_angle", "spin_rate"]:
+    _df[col] = pd.to_numeric(_df[col], errors="coerce")
 
-df = df_filtered.copy()
-st.subheader("Shot Dispersion")
-if "Offline" in df.columns:
-    carry_col = "Carry Distance" if "Carry Distance" in df.columns else "Carry"
-    if carry_col in df.columns:
-        df["Offline"] = pd.to_numeric(df["Offline"], errors="coerce")
-        df[carry_col] = pd.to_numeric(df[carry_col], errors="coerce")
-        hover_cols = ["Date", "Club"] if "Date" in df.columns else ["Club"]
-        fig_dispersion = px.scatter(
-            df,
-            x="Offline",
-            y=carry_col,
-            color="Club",
-            hover_data=hover_cols,
-            title="Lateral Dispersion vs Carry Distance",
+df = _df
+
+# Step 1: Add session selection dropdown
+sessions = df["session_name"].dropna().unique().tolist()
+selected_session = st.selectbox("Select Session", options=["All Sessions"] + sessions)
+df_filtered = df if selected_session == "All Sessions" else df[df["session_name"] == selected_session]
+
+# Step 2: Create a club summary table
+club_summary = df_filtered.groupby("club").agg(
+    total_shots=("carry_distance", "count"),
+    avg_carry=("carry_distance", "mean"),
+    std_carry=("carry_distance", "std"),
+    avg_ball_speed=("ball_speed", "mean"),
+    avg_launch_angle=("launch_angle", "mean"),
+    avg_spin_rate=("spin_rate", "mean"),
+).reset_index()
+
+st.markdown("## 🏌️‍♂️ Club Performance Summary")
+st.dataframe(
+    club_summary.style.format(
+        {
+            "avg_carry": "{:.1f}",
+            "std_carry": "{:.1f}",
+            "avg_ball_speed": "{:.1f}",
+            "avg_launch_angle": "{:.1f}",
+            "avg_spin_rate": "{:.0f}",
+        }
+    )
+)
+
+# Step 3: Add a bar chart of average carry distance per club
+fig_carry = px.bar(
+    club_summary,
+    x="club",
+    y="avg_carry",
+    text="avg_carry",
+    title="Average Carry Distance by Club",
+    labels={"avg_carry": "Avg Carry (yds)", "club": "Club"},
+)
+fig_carry.update_traces(texttemplate="%{text:.1f}", textposition="outside")
+st.plotly_chart(fig_carry, use_container_width=True)
+
+# Step 4: Add a pie chart for shot usage by club
+fig_pie = px.pie(
+    club_summary,
+    values="total_shots",
+    names="club",
+    title="Shot Volume by Club",
+)
+st.plotly_chart(fig_pie, use_container_width=True)
+
+# Step 5: Add red flag section for high variability clubs
+st.markdown("## ⚠️ Inconsistency Warning")
+high_variability = club_summary.sort_values("std_carry", ascending=False).head(3)
+st.dataframe(high_variability[["club", "std_carry"]].style.format("{:.1f}"))
+
+# Step 6: Add basic coach-style feedback
+st.markdown("## 📊 Coach’s Notes")
+for _, row in club_summary.iterrows():
+    if row["std_carry"] > 15:
+        st.write(
+            f"🟡 Your **{row['club']}** has a high carry distance variance ({row['std_carry']:.1f} yds). "
+            "Consider strike pattern drills or better clubface control."
         )
-        st.plotly_chart(fig_dispersion, use_container_width=True)
-    else:
-        st.warning("No carry distance data available for dispersion plot.")
-else:
-    st.warning("No 'Offline' column available for dispersion plot.")
-
-selected_club = st.sidebar.selectbox("Select a club to view", club_list)
-
-club_data = df[df["Club"] == selected_club]
-
-# Show basic stats
-st.subheader(f"Stats for {selected_club}")
-st.write(club_data.describe(include="all"))
-
-# Plot carry distance distribution
-if "Carry" in club_data.columns:
-    st.plotly_chart(
-        px.histogram(
-            club_data, x="Carry", nbins=20, title="Carry Distance Distribution"
+    if row["avg_carry"] < 100 and "wedge" in str(row["club"]).lower():
+        st.write(
+            f"⚠️ Your **{row['club']}** carry is lower than expected. "
+            "Check contact quality and ball-first strike."
         )
-    )
-elif "Carry Distance" in club_data.columns:
-    st.plotly_chart(
-        px.histogram(
-            club_data, x="Carry Distance", nbins=20, title="Carry Distance Distribution"
-        )
-    )
 
-# Launch angle and smash factor scatter plot
-if "Launch Angle" in club_data.columns and "Smash Factor" in club_data.columns:
-    st.plotly_chart(
-        px.scatter(
-            club_data,
-            x="Launch Angle",
-            y="Smash Factor",
-            title="Launch Angle vs Smash Factor",
-            trendline="ols",
-        )
-    )
+# Optional: Add expanders for each club with descriptive stats
+for club, club_df in df_filtered.groupby("club"):
+    with st.expander(f"{club} details"):
+        st.write(club_df[["carry_distance", "ball_speed", "launch_angle", "spin_rate"]].describe())


### PR DESCRIPTION
## Summary
- Replace dashboard with high-level club summary using standardized session data
- Add visual charts for average carry distance and shot volume per club
- Include inconsistency warnings and coach-style notes for quick feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fdff0f9288330a65e1151c0fd57ee