### PR TITLE
Handle duplicate columns when coercing numeric data

### DIFF
--- a/pages/0_Dashboard.py
+++ b/pages/0_Dashboard.py
@@ -9,6 +9,7 @@ import streamlit as st
 import pandas as pd
 import plotly.express as px
 from utils.logger import logger
+from utils.data_utils import coerce_numeric
 
 # Ensure session data is available
 if "session_df" not in st.session_state or st.session_state["session_df"].empty:
@@ -33,6 +34,10 @@ col_map = {
     "Spin Rate": "spin_rate",
 }
 _df = _df.rename(columns={k: v for k, v in col_map.items() if k in _df.columns})
+# ``rename`` may introduce duplicate column names (e.g., "Carry" and
+# "Carry Distance" both mapping to ``carry_distance``).  Drop duplicates to
+# ensure downstream column selection returns a Series instead of a DataFrame.
+_df = _df.loc[:, ~_df.columns.duplicated()]
 
 required_cols = [
     "session_name",
@@ -49,7 +54,7 @@ if missing:
 
 # Convert numeric columns
 for col in ["carry_distance", "ball_speed", "launch_angle", "spin_rate"]:
-    _df[col] = pd.to_numeric(_df[col], errors="coerce")
+    _df[col] = coerce_numeric(_df[col])
 
 df = _df
 

--- a/pages/2_Benchmark_Report.py
+++ b/pages/2_Benchmark_Report.py
@@ -18,6 +18,7 @@ logger.info("📄 Page loaded: 2 Benchmark Report")
 
 import pandas as pd
 from utils.benchmarks import get_benchmarks
+from utils.data_utils import coerce_numeric
 
 st.title("✅ Benchmark Comparison Report")
 
@@ -39,7 +40,7 @@ def compare_to_benchmark(club, club_df):
     club_df = club_df.copy()
     for col in ["Carry Distance", "Carry", "Smash Factor", "Launch Angle", "Backspin"]:
         if col in club_df.columns:
-            club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
+            club_df[col] = coerce_numeric(club_df[col])
 
     for metric, target in bmark.items():
         col = metric

--- a/pages/4_AI_Insights.py
+++ b/pages/4_AI_Insights.py
@@ -12,6 +12,7 @@ logger.info("📄 Page loaded: 4 AI Insights")
 
 import pandas as pd
 from utils.ai_feedback import generate_ai_summary
+from utils.data_utils import coerce_numeric
 
 st.title("🧠 AI Insights")
 
@@ -22,7 +23,7 @@ if "session_df" not in st.session_state or st.session_state["session_df"].empty:
 df = st.session_state["session_df"].copy()
 for col in ["Carry Distance", "Carry", "Smash Factor", "Launch Angle", "Backspin"]:
     if col in df.columns:
-        df[col] = pd.to_numeric(df[col], errors="coerce")
+        df[col] = coerce_numeric(df[col])
 club_list = sorted(df["Club"].dropna().unique())
 selected_club = st.selectbox("Select a club for feedback", club_list)
 

--- a/pages/5_AI_Practice_Summary.py
+++ b/pages/5_AI_Practice_Summary.py
@@ -10,6 +10,7 @@ if not uploaded_files:
 
 import pandas as pd
 from utils.practice_ai import analyze_practice_session
+from utils.data_utils import coerce_numeric
 
 st.title("🧠 AI Practice Summary")
 
@@ -27,7 +28,7 @@ if df is not None and not df.empty:
         "Offline",
     ]:
         if col in df.columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
+            df[col] = coerce_numeric(df[col])
     logger.info("Analyzing session with AI practice engine")
     results = analyze_practice_session(df)
 

--- a/pages/6_Benchmarking.py
+++ b/pages/6_Benchmarking.py
@@ -10,6 +10,7 @@ import pandas as pd
 import plotly.express as px
 
 from utils.logger import logger
+from utils.data_utils import coerce_numeric
 
 # Ensure data is loaded -----------------------------------------------------
 if "session_df" not in st.session_state or st.session_state["session_df"].empty:
@@ -41,6 +42,10 @@ col_map = {
 _df = st.session_state["session_df"].rename(
     columns={k: v for k, v in col_map.items() if k in st.session_state["session_df"].columns}
 )
+# ``rename`` can create duplicate columns when multiple source columns map to
+# the same standardised name (e.g., "Carry" and "Carry Distance").  Remove
+# duplicates so that subsequent ``df[col]`` lookups yield a Series.
+_df = _df.loc[:, ~_df.columns.duplicated()]
 
 required = [
     "club",
@@ -68,7 +73,7 @@ for col in [
     "offline_distance",
 ]:
     if col in _df.columns:
-        _df[col] = pd.to_numeric(_df[col], errors="coerce")
+        _df[col] = coerce_numeric(_df[col])
 
 df = _df.dropna(subset=["club", "session_name"])
 

--- a/utils/ai_feedback.py
+++ b/utils/ai_feedback.py
@@ -5,6 +5,7 @@ import openai
 from typing import Dict
 
 import pandas as pd
+from .data_utils import coerce_numeric
 
 
 def generate_ai_summary(club_name, df):
@@ -25,10 +26,10 @@ def generate_ai_summary(club_name, df):
     # Coerce numeric columns to floats; missing columns result in NaN values so
     # that formatting below does not raise ``TypeError``.
     if carry_col in shots.columns:
-        shots[carry_col] = pd.to_numeric(shots[carry_col], errors="coerce")
+        shots[carry_col] = coerce_numeric(shots[carry_col])
     for col in ["Smash Factor", "Launch Angle", "Backspin"]:
         if col in shots.columns:
-            shots[col] = pd.to_numeric(shots[col], errors="coerce")
+            shots[col] = coerce_numeric(shots[col])
 
     carry = shots[carry_col].mean() if carry_col in shots.columns else float("nan")
     smash = shots["Smash Factor"].mean() if "Smash Factor" in shots.columns else float("nan")
@@ -119,10 +120,10 @@ def generate_ai_batch_summaries(df) -> Dict[str, str]:
         carry_col = "Carry Distance" if "Carry Distance" in shots.columns else "Carry"
         shots = shots.copy()
         if carry_col in shots.columns:
-            shots[carry_col] = pd.to_numeric(shots[carry_col], errors="coerce")
+            shots[carry_col] = coerce_numeric(shots[carry_col])
         for col in ["Smash Factor", "Launch Angle", "Backspin"]:
             if col in shots.columns:
-                shots[col] = pd.to_numeric(shots[col], errors="coerce")
+                shots[col] = coerce_numeric(shots[col])
         carry = shots[carry_col].mean() if carry_col in shots.columns else float("nan")
         smash = shots["Smash Factor"].mean() if "Smash Factor" in shots.columns else float("nan")
         launch = shots["Launch Angle"].mean() if "Launch Angle" in shots.columns else float("nan")

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+
+def coerce_numeric(series, errors: str = "coerce"):
+    """Return numeric values for ``series`` even if duplicates exist.
+
+    When a :class:`pandas.DataFrame` contains duplicate column names, indexing a
+    column (``df[col]``) returns another ``DataFrame`` rather than a
+    ``Series``.  ``pd.to_numeric`` expects a one-dimensional input and will
+    raise ``TypeError`` in this scenario.  This helper picks the first column if
+    ``series`` is a ``DataFrame`` before coercing the values to numeric.
+    """
+
+    if isinstance(series, pd.DataFrame):
+        series = series.iloc[:, 0]
+    return pd.to_numeric(series, errors=errors)

--- a/utils/drill_recommendations.py
+++ b/utils/drill_recommendations.py
@@ -13,6 +13,7 @@ from typing import Dict, List
 import pandas as pd
 
 from .benchmarks import get_benchmarks
+from .data_utils import coerce_numeric
 
 
 @dataclass
@@ -88,11 +89,12 @@ def recommend_drills(df: pd.DataFrame) -> Dict[str, List[Recommendation]]:
         is_wedge = any(keyword in club_lower for keyword in wedge_keywords)
 
         # Work on a copy and coerce relevant columns to numeric to avoid
-        # ``TypeError`` when the source data contains strings.
+        # ``TypeError`` when the source data contains strings or duplicate
+        # column names.
         club_df = club_df.copy()
         for col in ["Smash Factor", "Carry Distance", "Launch Angle", "Backspin"]:
             if col in club_df.columns:
-                club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
+                club_df[col] = coerce_numeric(club_df[col])
 
         if bench.get("Smash Factor") is not None and "Smash Factor" in club_df.columns:
             if club_df["Smash Factor"].min() < bench["Smash Factor"]:

--- a/utils/performance_summary.py
+++ b/utils/performance_summary.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from .drill_recommendations import Recommendation, recommend_drills
 from .benchmarks import get_benchmarks
+from .data_utils import coerce_numeric
 
 
 @dataclass
@@ -104,11 +105,11 @@ def summarize_performance(df: pd.DataFrame) -> str:
     for option in ("Carry Distance", "Carry"):
         if option in df.columns:
             carry_col = option
-            df[carry_col] = pd.to_numeric(df[carry_col], errors="coerce")
+            df[carry_col] = coerce_numeric(df[carry_col])
             break
 
     if "Offline" in df.columns:
-        df["Offline"] = pd.to_numeric(df["Offline"], errors="coerce")
+        df["Offline"] = coerce_numeric(df["Offline"])
 
     misses = MissCounts()
     if carry_col or "Offline" in df.columns:

--- a/utils/practice_ai.py
+++ b/utils/practice_ai.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 from openai import OpenAI
 import os
+from .data_utils import coerce_numeric
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
@@ -20,7 +21,7 @@ def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
     # Clean and cast existing columns only
     for col in ["Carry Distance", "Launch Angle", "Spin Rate", "Smash Factor", "Offline"]:
         if col in club_df.columns:
-            club_df[col] = pd.to_numeric(club_df[col], errors="coerce")
+            club_df[col] = coerce_numeric(club_df[col])
 
     avg_smash = club_df["Smash Factor"].mean() if "Smash Factor" in club_df else np.nan
     avg_launch = club_df["Launch Angle"].mean() if "Launch Angle" in club_df else np.nan


### PR DESCRIPTION
## Summary
- Avoid TypeError on pages when duplicated source columns map to the same name
- Centralize numeric coercion in `coerce_numeric` helper and use across modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fe740933c83309e8447e524465918