### PR TITLE
feat: improve responsive layout

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -13,8 +13,9 @@ import streamlit as st
 
 from utils.logger import logger
 from utils.session_loader import load_sessions
+from utils.responsive import configure_page
 
-st.set_page_config(page_title="Garmin R10 Analyzer", layout="wide")
+configure_page()
 st.title("📊 Garmin R10 Analyzer")
 
 CACHE_PATH = os.path.join("sample_data", "session_cache.pkl")

--- a/pages/0_Analysis.py
+++ b/pages/0_Analysis.py
@@ -7,8 +7,10 @@ import streamlit as st
 from utils.logger import logger
 from utils.data_utils import coerce_numeric
 from utils.page_utils import require_data
+from utils.responsive import configure_page
 
 logger.info("📄 Page loaded: Analysis")
+configure_page()
 st.title("📈 Analysis")
 
 # Load and standardise data -------------------------------------------------

--- a/pages/1_Sessions.py
+++ b/pages/1_Sessions.py
@@ -7,8 +7,10 @@ from datetime import datetime
 
 from utils.logger import logger
 from utils.page_utils import require_data
+from utils.responsive import configure_page
 
 logger.info("📄 Page loaded: Sessions")
+configure_page()
 st.title("📋 Sessions")
 
 df_all = require_data().copy()

--- a/pages/3_AI_Feedback.py
+++ b/pages/3_AI_Feedback.py
@@ -7,8 +7,10 @@ from utils.data_utils import coerce_numeric
 from utils.ai_feedback import generate_ai_summary
 from utils.practice_ai import analyze_practice_session
 from utils.page_utils import require_data
+from utils.responsive import configure_page
 
 logger.info("📄 Page loaded: AI Feedback")
+configure_page()
 st.title("🧠 AI Feedback")
 
 df = require_data().copy()

--- a/utils/responsive.py
+++ b/utils/responsive.py
@@ -1,0 +1,30 @@
+"""Utility functions for mobile-friendly responsive layouts."""
+
+import streamlit as st
+
+
+def configure_page() -> None:
+    """Apply global page config and responsive CSS.
+
+    Sets a wide layout for desktop use while injecting media-query CSS so the
+    Streamlit app remains readable on small mobile screens.  The CSS reduces
+    default padding and allows tab labels to wrap when the viewport is narrow.
+    """
+
+    st.set_page_config(page_title="Garmin R10 Analyzer", layout="wide")
+    st.markdown(
+        """
+        <style>
+        @media (max-width: 600px) {
+            .block-container {
+                padding-left: 0.5rem;
+                padding-right: 0.5rem;
+            }
+            .stTabs [data-baseweb="tab-list"] {
+                flex-wrap: wrap;
+            }
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )


### PR DESCRIPTION
## Summary
- add responsive layout utility and CSS for mobile/desktop
- apply unified page configuration across all Streamlit pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffc2762cc8330bf286f72ae1d1c23