### PR TITLE
Implement outlier filtering and shot trend analysis

### DIFF
--- a/test_data_utils.py
+++ b/test_data_utils.py
@@ -1,0 +1,7 @@
+import pandas as pd
+from utils.data_utils import remove_outliers
+
+def test_remove_outliers_drops_extreme_values():
+    df = pd.DataFrame({'Metric': [1, 2, 3, 100]})
+    filtered = remove_outliers(df, ['Metric'])
+    assert 100 not in filtered['Metric'].values

--- a/test_practice_ai.py
+++ b/test_practice_ai.py
@@ -1,0 +1,56 @@
+import pandas as pd
+from utils.practice_ai import analyze_club_stats, analyze_practice_session
+
+def test_analyze_club_stats_ignores_outliers_and_reports_max():
+    df = pd.DataFrame({
+        "Club": ["7 Iron"] * 7,
+        "Carry Distance": [150, 151, 152, 400, 149, 150, 151],
+        "Smash Factor": [1.33, 1.34, 1.35, 1.20, 1.32, 1.33, 1.34],
+    })
+    result = analyze_club_stats(df, "7 Iron")
+    assert result["max_good_carry"] == 152
+
+
+def test_analyze_club_stats_can_disable_outlier_filter():
+    df = pd.DataFrame({
+        "Club": ["7 Iron"] * 6,
+        "Carry Distance": [150, 151, 152, 400, 149, 150],
+        "Smash Factor": [1.33, 1.34, 1.35, 1.20, 1.32, 1.33],
+    })
+    result = analyze_club_stats(df, "7 Iron", filter_outliers=False)
+    assert result["max_good_carry"] == 400
+
+def test_analyze_club_stats_detects_fat_trend():
+    df = pd.DataFrame({
+        "Club": ["Driver"] * 7,
+        "Carry Distance": [230, 231, 229, 228, 232, 231, 229],
+        "Smash Factor": [1.10, 1.12, 1.11, 1.13, 1.09, 1.10, 1.11],
+    })
+    result = analyze_club_stats(df, "Driver")
+    assert any("fat or chunked" in issue for issue in result["issues"])
+
+
+def test_analyze_practice_session_skips_clubs_with_few_shots():
+    df = pd.DataFrame(
+        {
+            "Club": ["7 Iron"] * 7 + ["Driver"] * 5,
+            "Carry Distance": [150, 151, 152, 153, 150, 151, 152, 230, 231, 229, 228, 232],
+            "Smash Factor": [
+                1.33,
+                1.34,
+                1.35,
+                1.33,
+                1.32,
+                1.33,
+                1.34,
+                1.10,
+                1.12,
+                1.11,
+                1.13,
+                1.09,
+            ],
+        }
+    )
+    results = analyze_practice_session(df)
+    clubs = [r["club"] for r in results]
+    assert "7 Iron" in clubs and "Driver" not in clubs

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -14,3 +14,29 @@ def coerce_numeric(series, errors: str = "coerce"):
     if isinstance(series, pd.DataFrame):
         series = series.iloc[:, 0]
     return pd.to_numeric(series, errors=errors)
+
+
+def remove_outliers(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+    """Return ``df`` with outliers removed for the given ``cols``.
+
+    Outliers are detected using the 1.5 * IQR rule for each column. Rows
+    outside the acceptable range for any provided column are dropped. Columns
+    that are not present in ``df`` are ignored. ``df`` is not modified in
+    place.
+    """
+
+    filtered = df.copy()
+    for col in cols:
+        if col not in filtered.columns:
+            continue
+        series = coerce_numeric(filtered[col]).dropna()
+        if series.empty:
+            continue
+        q1 = series.quantile(0.25)
+        q3 = series.quantile(0.75)
+        iqr = q3 - q1
+        lower = q1 - 1.5 * iqr
+        upper = q3 + 1.5 * iqr
+        mask = series.between(lower, upper)
+        filtered = filtered.loc[mask]
+    return filtered

--- a/utils/practice_ai.py
+++ b/utils/practice_ai.py
@@ -4,13 +4,22 @@ import pandas as pd
 import numpy as np
 from openai import OpenAI
 import os
-from .data_utils import coerce_numeric
+from .data_utils import coerce_numeric, remove_outliers
+from .benchmarks import get_benchmarks
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 
-def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
-    """Analyse shots for a single club and return issues and an AI summary."""
+def analyze_club_stats(
+    df: pd.DataFrame, club: str, *, filter_outliers: bool = True
+) -> dict | None:
+    """Analyse shots for a single club and return issues and an AI summary.
+
+    ``filter_outliers`` controls whether extreme values are removed prior to
+    computing statistics. Outlier removal is enabled by default but can be
+    disabled by passing ``False``.
+    """
 
     feedback = []
     club_df = df[df["Club"] == club].copy()
@@ -18,10 +27,26 @@ def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
     if club_df.empty:
         return {"club": club, "issues": ["No data"], "summary": "No data available."}
 
+    numeric_cols = [
+        "Carry Distance",
+        "Launch Angle",
+        "Spin Rate",
+        "Smash Factor",
+        "Offline",
+    ]
+
     # Clean and cast existing columns only
-    for col in ["Carry Distance", "Launch Angle", "Spin Rate", "Smash Factor", "Offline"]:
+    for col in numeric_cols:
         if col in club_df.columns:
             club_df[col] = coerce_numeric(club_df[col])
+
+    # Remove outliers so a few wild shots don't skew statistics
+    if filter_outliers:
+        club_df = remove_outliers(club_df, numeric_cols)
+
+    # Skip clubs without enough data to be meaningful
+    if len(club_df) < 6:
+        return None
 
     avg_smash = club_df["Smash Factor"].mean() if "Smash Factor" in club_df else np.nan
     avg_launch = club_df["Launch Angle"].mean() if "Launch Angle" in club_df else np.nan
@@ -36,11 +61,24 @@ def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
         (club_df["Offline"] > 0).mean() * 100 if "Offline" in club_df else 0
     )
 
-    # Rules
-    if avg_smash < 1.2:
-        feedback.append("Low smash factor suggests poor contact (fat or off-center hits).")
-    elif avg_smash > 1.5:
-        feedback.append("High smash factor might mean thin or toe strikes.")
+    # Contact trends via smash factor
+    if "Smash Factor" in club_df:
+        smash = club_df["Smash Factor"].dropna()
+        fat_rate = (smash < 1.2).mean() if not smash.empty else 0
+        thin_rate = (smash > 1.5).mean() if not smash.empty else 0
+        if fat_rate > 0.3:
+            feedback.append(f"{fat_rate*100:.0f}% of shots were fat or chunked.")
+        if thin_rate > 0.3:
+            feedback.append(f"{thin_rate*100:.0f}% of shots were thin strikes.")
+        if fat_rate <= 0.3 and thin_rate <= 0.3:
+            if avg_smash < 1.2:
+                feedback.append(
+                    "Low smash factor suggests poor contact (fat or off-center hits)."
+                )
+            elif avg_smash > 1.5:
+                feedback.append(
+                    "High smash factor might mean thin or toe strikes."
+                )
 
     if avg_launch < 10:
         feedback.append("Launch angle is too low — possibly de-lofted or poor strike.")
@@ -53,17 +91,43 @@ def analyze_club_stats(df: pd.DataFrame, club: str) -> dict:
         feedback.append("High spin could be from poor contact or wet range balls.")
 
     if left_bias > 60:
-        feedback.append(f"You're missing left {left_bias:.0f}% of the time — face/path issue likely.")
+        feedback.append(
+            f"You're missing left {left_bias:.0f}% of the time — face/path issue likely."
+        )
     elif right_bias > 60:
-        feedback.append(f"You're missing right {right_bias:.0f}% of the time — face/path issue likely.")
+        feedback.append(
+            f"You're missing right {right_bias:.0f}% of the time — face/path issue likely."
+        )
 
     if std_carry > 15:
         feedback.append("High carry distance variability suggests inconsistent contact.")
 
+    # Max carry of a good shot based on benchmarks
+    benchmark_carry = None
+    for key, vals in get_benchmarks().items():
+        if key.lower() in club.lower() and "Carry" in vals:
+            benchmark_carry = vals["Carry"]
+            break
+
+    max_good_carry = np.nan
+    if "Carry Distance" in club_df:
+        carries = club_df["Carry Distance"].dropna()
+        if benchmark_carry is not None:
+            good_shots = carries[carries >= 0.9 * benchmark_carry]
+        else:
+            good_shots = carries
+        if not good_shots.empty:
+            max_good_carry = good_shots.max()
+            if benchmark_carry is not None:
+                feedback.append(
+                    f"Best good carry: {max_good_carry:.0f} yds (target {benchmark_carry} yds)."
+                )
+
     return {
         "club": club,
         "summary": summarize_with_ai(club, feedback),
-        "issues": feedback
+        "issues": feedback,
+        "max_good_carry": max_good_carry,
     }
 
 def summarize_with_ai(club: str, issues: list[str]) -> str:
@@ -71,6 +135,9 @@ def summarize_with_ai(club: str, issues: list[str]) -> str:
 
     if not issues:
         return f"Your {club} data looks solid — no major red flags detected. Nice work!"
+
+    if client is None:
+        return "(AI summary disabled: no API key)"
 
     prompt = f"""
     A golfer hit a series of shots with a {club}. Based on these observations:
@@ -88,12 +155,24 @@ def summarize_with_ai(club: str, issues: list[str]) -> str:
     except Exception as e:
         return f"(AI summary failed: {e})"
 
-def analyze_practice_session(df: pd.DataFrame) -> list[dict]:
-    """Generate practice feedback for each club in ``df``."""
+def analyze_practice_session(
+    df: pd.DataFrame, *, filter_outliers: bool = True
+) -> list[dict]:
+    """Generate practice feedback for each club in ``df``.
+
+    ``filter_outliers`` mirrors the argument in :func:`analyze_club_stats` and
+    controls whether per-club analysis removes outliers. It is enabled by
+    default.
+    """
     # ``df`` may come from arbitrary CSVs.  Guard against the ``Club`` column
     # being missing to avoid ``KeyError``s when the caller supplies malformed
     # data.
     if "Club" not in df.columns:
         return []
     clubs = df["Club"].dropna().unique()
-    return [analyze_club_stats(df, club) for club in clubs]
+    results: list[dict] = []
+    for club in clubs:
+        stats = analyze_club_stats(df, club, filter_outliers=filter_outliers)
+        if stats is not None:
+            results.append(stats)
+    return results


### PR DESCRIPTION
## Summary
- Add optional `filter_outliers` flag (default on) and skip clubs with fewer than six shots
- Expand practice analysis tests for outlier toggle and minimum-shot behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689001e79560833083a651ea5b7a934f