### PR TITLE
Fix remove_outliers index alignment

### DIFF
--- a/test_data_utils.py
+++ b/test_data_utils.py
@@ -7,6 +7,14 @@ def test_remove_outliers_drops_extreme_values():
     assert 100 not in filtered['Metric'].values
 
 
+def test_remove_outliers_handles_missing_values():
+    df = pd.DataFrame({'Metric': [1, 2, None, 3, 100]})
+    filtered = remove_outliers(df, ['Metric'])
+    assert 100 not in filtered['Metric'].values
+    # Missing values should be retained
+    assert filtered['Metric'].isna().sum() == 1
+
+
 def test_derive_offline_distance_from_side():
     df = pd.DataFrame({"Side Distance": [5, -3]})
     result = derive_offline_distance(df)

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -29,15 +29,17 @@ def remove_outliers(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
     for col in cols:
         if col not in filtered.columns:
             continue
-        series = coerce_numeric(filtered[col]).dropna()
-        if series.empty:
+        # Use the full column for masking so index alignment is preserved
+        series = coerce_numeric(filtered[col])
+        valid = series.dropna()
+        if valid.empty:
             continue
-        q1 = series.quantile(0.25)
-        q3 = series.quantile(0.75)
+        q1 = valid.quantile(0.25)
+        q3 = valid.quantile(0.75)
         iqr = q3 - q1
         lower = q1 - 1.5 * iqr
         upper = q3 + 1.5 * iqr
-        mask = series.between(lower, upper)
+        mask = series.between(lower, upper) | series.isna()
         filtered = filtered.loc[mask]
     return filtered
 


### PR DESCRIPTION
## Summary
- prevent `remove_outliers` from failing when data contains missing values by masking using the full column
- add regression test verifying outlier removal retains NaNs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900e212c98833092ed04cfa880bdf8