### PR TITLE
Enable outlier filtering by default on analysis page

### DIFF
--- a/pages/0_Analysis.py
+++ b/pages/0_Analysis.py
@@ -87,7 +87,7 @@ else:  # Select Sessions
         df[df["session_name"].isin(chosen)] if chosen else df.iloc[0:0]
     )
 
-filter_outliers = st.checkbox("Filter outliers", value=False)
+filter_outliers = st.checkbox("Filter outliers", value=True)
 if filter_outliers:
     numeric_cols = [
         "carry_distance",


### PR DESCRIPTION
## Summary
- Enable the outlier filtering checkbox by default on the Analysis page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689011092a808330aea8c3b0e653b297