### PR TITLE
Enable outlier filtering by default on analysis page

### DIFF
--- a/pages/0_Analysis.py
+++ b/pages/0_Analysis.py
@@ -87,7 +87,7 @@ else:  # Select Sessions
         df[df["session_name"].isin(chosen)] if chosen else df.iloc[0:0]
     )
 
-filter_outliers = st.checkbox("Filter outliers", value=False)
+filter_outliers = st.checkbox("Filter outliers", value=True)
 if filter_outliers:
     numeric_cols = [
         "carry_distance",

--- a/test_data_utils.py
+++ b/test_data_utils.py
@@ -15,8 +15,22 @@ def test_remove_outliers_handles_missing_values():
     assert filtered['Metric'].isna().sum() == 1
 
 
+def test_remove_outliers_multiple_columns():
+    df = pd.DataFrame({'A': [1, 1, 1, 1, 100], 'B': [1, 1, 1, 1, 1]})
+    filtered = remove_outliers(df, ['A', 'B'])
+    assert 100 not in filtered['A'].values
+    assert len(filtered) == 4
+
+
 def test_derive_offline_distance_from_side():
     df = pd.DataFrame({"Side Distance": [5, -3]})
     result = derive_offline_distance(df)
     assert "Offline" in result.columns
     assert result["Offline"].tolist() == [5, -3]
+
+
+def test_derive_offline_distance_from_side_column():
+    df = pd.DataFrame({"Side": [4, -2]})
+    result = derive_offline_distance(df)
+    assert "Offline" in result.columns
+    assert result["Offline"].tolist() == [4, -2]


### PR DESCRIPTION
## Summary
- Enable the outlier filtering checkbox by default on the Analysis page
- Add tests confirming outlier filtering and offline distance derivation work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689011092a808330aea8c3b0e653b297