### PR TITLE
Name sessions by date and handle duplicates

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -133,12 +133,18 @@ def remove_file(name: str) -> None:
         st.session_state["uploaded_files"].remove(name)
         if "session_df" in st.session_state and not st.session_state["session_df"].empty:
             session_df = st.session_state["session_df"]
-            if "Session Name" in session_df.columns:
+            if "Source File" in session_df.columns:
+                st.session_state["session_df"] = session_df[
+                    session_df["Source File"] != name
+                ]
+            elif "Session Name" in session_df.columns:
                 st.session_state["session_df"] = session_df[
                     session_df["Session Name"] != name
                 ]
             else:
-                logger.warning("Missing 'Session Name' column while removing %s", name)
+                logger.warning(
+                    "Missing 'Source File' column while removing %s", name
+                )
             st.session_state["df_all"] = st.session_state["session_df"]
             if "Club" in st.session_state["session_df"].columns:
                 st.session_state["club_data"] = {

--- a/test_session_loader.py
+++ b/test_session_loader.py
@@ -1,0 +1,27 @@
+import io
+import pandas as pd
+
+from utils.session_loader import load_sessions
+
+
+def _make_file(content: str, name: str):
+    buf = io.StringIO(content)
+    buf.name = name
+    return buf
+
+
+def test_load_sessions_names_by_date():
+    f1 = _make_file("Date,Club\n2025-08-01 10:00,Driver\n", "a.csv")
+    f2 = _make_file("Date,Club\n2025-08-02 09:00,Driver\n", "b.csv")
+    df = load_sessions([f1, f2])
+    names = df["Session Name"].drop_duplicates().tolist()
+    assert names == ["2025-08-01", "2025-08-02"]
+    assert set(df["Source File"].unique()) == {"a.csv", "b.csv"}
+
+
+def test_load_sessions_numbers_duplicate_dates():
+    later = _make_file("Date,Club\n2025-08-01 15:00,Driver\n", "late.csv")
+    earlier = _make_file("Date,Club\n2025-08-01 09:00,Driver\n", "early.csv")
+    df = load_sessions([later, earlier])
+    names = df["Session Name"].drop_duplicates().tolist()
+    assert names == ["2025-08-01", "2025-08-01 #2"]

--- a/utils/session_loader.py
+++ b/utils/session_loader.py
@@ -1,20 +1,28 @@
 """Utilities for loading and normalising Garmin session CSV files."""
 
-import pandas as pd
 import io
+from typing import List
+
+import pandas as pd
 
 from .data_utils import derive_offline_distance
 
 
-def load_sessions(files):
+def load_sessions(files: List[object]) -> pd.DataFrame:
     """Return a concatenated dataframe from uploaded CSV ``files``.
 
-    Each file is read into a dataframe, annotated with the original file name
-    and normalised so that a ``Club`` column is always present. Any files that
-    fail to parse are skipped with a printed warning.
+    Sessions are named using the earliest timestamp in each file.  If multiple
+    files share the same date, a session number is appended based on the
+    chronological order of their timestamps (e.g. ``2025-08-01`` and
+    ``2025-08-01 #2``).  The original file name is preserved in the ``Source
+    File`` column so files can still be removed individually later.
+
+    Each file is read into a dataframe, normalised so that a ``Club`` column is
+    always present and annotated with session metadata. Any files that fail to
+    parse are skipped with a printed warning.
     """
 
-    dfs = []
+    sessions = []
     for file in files:
         try:
             # ``UploadedFile`` objects from Streamlit expose ``getvalue``.
@@ -37,14 +45,51 @@ def load_sessions(files):
                 content = str(raw)
 
             df = pd.read_csv(io.StringIO(content))
-            df["Session Name"] = getattr(file, "name", "Unknown")
             # Normalise club column name
             if "Club" not in df.columns and "Club Type" in df.columns:
                 df["Club"] = df["Club Type"]
             df = derive_offline_distance(df)
-            dfs.append(df)
+
+            # Parse dates to determine session naming
+            first_dt = pd.NaT
+            if "Date" in df.columns:
+                df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+                first_dt = df["Date"].min()
+
+            sessions.append({
+                "df": df,
+                "first_dt": first_dt,
+                "file_name": getattr(file, "name", "Unknown"),
+            })
         except Exception as e:
             print(f"Failed to load {getattr(file, 'name', 'unknown')}: {e}")
-    if dfs:
-        return pd.concat(dfs, ignore_index=True)
-    return pd.DataFrame()
+
+    if not sessions:
+        return pd.DataFrame()
+
+    # Sort sessions by their earliest timestamp
+    sessions.sort(key=lambda x: (pd.isna(x["first_dt"]), x["first_dt"]))
+
+    # Assign session names, handling multiple sessions on the same date
+    counts = {}
+    dfs = []
+    for session in sessions:
+        df = session["df"]
+        first_dt = session["first_dt"]
+        file_name = session["file_name"]
+
+        if pd.notna(first_dt):
+            date_str = first_dt.date().isoformat()
+            counts[date_str] = counts.get(date_str, 0) + 1
+            count = counts[date_str]
+            session_name = (
+                f"{date_str} #{count}" if count > 1 else date_str
+            )
+        else:
+            session_name = file_name
+
+        df["Session Name"] = session_name
+        df["Source File"] = file_name
+        dfs.append(df)
+
+    return pd.concat(dfs, ignore_index=True)


### PR DESCRIPTION
## Summary
- Derive session names from the earliest shot date in each file and append counters when multiple sessions occur on the same day, retaining original file names in a new `Source File` column
- Update file-removal logic to drop rows based on `Source File` so uploaded sessions remain manageable
- Add tests covering new session naming and duplicate-date handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68901bb481508330b8cc9850b2c6f291