### PR TITLE
feat: add shot quality tagging and trend analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,19 @@ A Streamlit-based app for analyzing and improving your golf performance using da
 - Benchmarking tab explores dispersion and shot-level metrics
 - Interactive Plotly charts for carry distance and dispersion
 - Smart session and club filtering
+- Adjustable outlier controls and percentile benchmarks
+- Filter analysis to "quality" shots only
 
 ### 📋 Sessions Page
-- Table viewer for raw shot data
+- Editable table viewer for raw shot data with manual shot tagging
+- Exclude whole sessions from analysis when needed
 - Built-in practice log to capture notes and drills
 - Download logs as CSV
+
+### 📉 Trends Page
+- Track carry distance progression for each club across sessions
+- Optional rolling average smoothing
+- Quality-shot filtering for more reliable trends
 
 ### 🧠 AI Feedback (Optional)
 - Requires `OPENAI_API_KEY` and `OPENAI_ASSISTANT_ID` environment variables

--- a/pages/2_Trends.py
+++ b/pages/2_Trends.py
@@ -1,0 +1,70 @@
+"""Trend and progression analysis page."""
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from utils.page_utils import require_data
+from utils.responsive import configure_page
+from utils.data_utils import classify_shots
+
+configure_page()
+st.title("📉 Trends")
+
+df = require_data().copy()
+if df.empty:
+    st.info("Upload session data to view trends.")
+    st.stop()
+
+if "Date" in df.columns:
+    df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+
+df = classify_shots(df)
+use_quality = st.checkbox("Use only quality shots", value=True)
+if use_quality and "Quality" in df.columns:
+    df = df[df["Quality"] == "good"]
+
+if df.empty:
+    st.info("No data available after filtering.")
+    st.stop()
+
+summary = (
+    df.groupby(["Session Name", "Club"])["Carry Distance"].mean().reset_index()
+)
+
+club_options = sorted(summary["Club"].dropna().unique())
+selected_club = st.selectbox("Select club", club_options)
+club_df = summary[summary["Club"] == selected_club].copy()
+
+if "Date" in df.columns:
+    order = (
+        df.drop_duplicates("Session Name")
+        .sort_values("Date")
+        ["Session Name"]
+        .tolist()
+    )
+    club_df["Session Name"] = pd.Categorical(
+        club_df["Session Name"], categories=order, ordered=True
+    )
+    club_df = club_df.sort_values("Session Name")
+
+fig = px.line(
+    club_df,
+    x="Session Name",
+    y="Carry Distance",
+    markers=True,
+    title=f"Average Carry Trend – {selected_club}",
+)
+st.plotly_chart(fig, use_container_width=True)
+
+window = st.slider("Rolling window", 1, 5, 3)
+if len(club_df) >= window:
+    club_df["Rolling"] = club_df["Carry Distance"].rolling(window).mean()
+    fig_roll = px.line(
+        club_df,
+        x="Session Name",
+        y="Rolling",
+        markers=True,
+        title=f"{selected_club} {window}-session rolling average",
+    )
+    st.plotly_chart(fig_roll, use_container_width=True)

--- a/test_data_utils.py
+++ b/test_data_utils.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from utils.data_utils import remove_outliers, derive_offline_distance
+from utils.data_utils import remove_outliers, derive_offline_distance, classify_shots
 
 def test_remove_outliers_drops_extreme_values():
     df = pd.DataFrame({'Metric': [1, 2, 3, 100]})
@@ -37,6 +37,14 @@ def test_remove_outliers_groups_by_club():
     assert 50 in wedge_carries.values
 
 
+def test_remove_outliers_custom_threshold():
+    df = pd.DataFrame({'Metric': [1, 2, 3, 10]})
+    tight = remove_outliers(df, ['Metric'], z_thresh=1.0)
+    assert 10 not in tight['Metric'].values
+    loose = remove_outliers(df, ['Metric'], z_thresh=10.0)
+    assert 10 in loose['Metric'].values
+
+
 def test_derive_offline_distance_from_side():
     df = pd.DataFrame({"Side Distance": [5, -3]})
     result = derive_offline_distance(df)
@@ -49,3 +57,12 @@ def test_derive_offline_distance_from_side_column():
     result = derive_offline_distance(df)
     assert "Offline" in result.columns
     assert result["Offline"].tolist() == [4, -2]
+
+
+def test_classify_shots_labels_quality():
+    df = pd.DataFrame({
+        'Carry Distance': [200, 50, 205],
+        'Offline': [0, 20, -2]
+    })
+    result = classify_shots(df)
+    assert result['Quality'].tolist() == ['good', 'outlier', 'good']


### PR DESCRIPTION
## Summary
- make outlier filtering configurable and classify shots as good/miss/outlier
- allow manual shot tagging and session exclusion from analysis
- add trends page and percentile benchmarks for deeper insights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68916fe44ecc833085832babe88b3348