### PR TITLE
Improve resilience for session state and AI helpers

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -5,6 +5,7 @@ between reloads. Uploaded CSV files are combined into a single dataframe and
 cached on disk so the user can navigate between pages without losing data.
 """
 
+import atexit
 import json
 import os
 from threading import Timer
@@ -22,6 +23,17 @@ st.title("📊 Garmin R10 Analyzer")
 CACHE_PATH = os.path.join("sample_data", "session_cache.json")
 
 _persist_timer: Timer | None = None
+
+
+def _cancel_timer() -> None:
+    """Cancel any pending persistence timer on app shutdown."""
+
+    global _persist_timer
+    if _persist_timer and _persist_timer.is_alive():
+        _persist_timer.cancel()
+
+
+atexit.register(_cancel_timer)
 
 
 def persist_state(delay: float = 0.5) -> None:

--- a/pages/1_Sessions.py
+++ b/pages/1_Sessions.py
@@ -21,68 +21,71 @@ viewer_tab, log_tab = st.tabs(["Viewer", "Practice Log"])
 with viewer_tab:
     st.subheader("Session Data")
     session_names = df_all["Session Name"].dropna().unique().tolist()
-    view_option = st.selectbox(
-        "Choose sessions to display",
-        ["Latest Session", "Last 5 Sessions", "Select Sessions"],
-    )
-
-    if "Date" in df_all.columns:
-        df_all["Date"] = pd.to_datetime(df_all["Date"], errors="coerce")
-
-    if view_option == "Latest Session":
-        if "Date" in df_all.columns and df_all["Date"].notna().any():
-            latest_session = df_all.loc[df_all["Date"].idxmax(), "Session Name"]
-        else:
-            latest_session = session_names[-1]
-        df_view = df_all[df_all["Session Name"] == latest_session]
-    elif view_option == "Last 5 Sessions":
-        if "Date" in df_all.columns and df_all["Date"].notna().any():
-            session_order = (
-                df_all.drop_duplicates("Session Name").sort_values("Date")
-            )["Session Name"].tolist()
-        else:
-            session_order = session_names
-        last_sessions = session_order[-5:]
-        df_view = df_all[df_all["Session Name"].isin(last_sessions)]
-    else:  # Select Sessions
-        chosen = st.multiselect("Select session(s)", session_names)
-        df_view = (
-            df_all[df_all["Session Name"].isin(chosen)] if chosen else df_all.iloc[0:0]
+    if not session_names:
+        st.info("No sessions available.")
+    else:
+        view_option = st.selectbox(
+            "Choose sessions to display",
+            ["Latest Session", "Last 5 Sessions", "Select Sessions"],
         )
-    exclude_sessions = st.multiselect(
-        "Exclude sessions from analysis",
-        session_names,
-        st.session_state.get("exclude_sessions", []),
-    )
-    st.session_state["exclude_sessions"] = exclude_sessions
 
-    df_view = classify_shots(df_view)
-    df_view = df_view.reset_index().rename(columns={"index": "_idx"})
+        if "Date" in df_all.columns:
+            df_all["Date"] = pd.to_datetime(df_all["Date"], errors="coerce")
 
-    bulk_tag = st.selectbox(
-        "Bulk set quality for all visible shots",
-        ["", "good", "miss", "outlier"],
-    )
-    if st.button("Apply tag") and bulk_tag:
-        df_view["Quality"] = bulk_tag
-
-    edited = st.data_editor(
-        df_view,
-        hide_index=True,
-        key="tag_editor",
-        column_config={
-            "Quality": st.column_config.SelectboxColumn(
-                "Quality", options=["good", "miss", "outlier"], default="good"
+        if view_option == "Latest Session":
+            if "Date" in df_all.columns and df_all["Date"].notna().any():
+                latest_session = df_all.loc[df_all["Date"].idxmax(), "Session Name"]
+            else:
+                latest_session = session_names[-1]
+            df_view = df_all[df_all["Session Name"] == latest_session]
+        elif view_option == "Last 5 Sessions":
+            if "Date" in df_all.columns and df_all["Date"].notna().any():
+                session_order = (
+                    df_all.drop_duplicates("Session Name").sort_values("Date")
+                )["Session Name"].tolist()
+            else:
+                session_order = session_names
+            last_sessions = session_order[-5:]
+            df_view = df_all[df_all["Session Name"].isin(last_sessions)]
+        else:  # Select Sessions
+            chosen = st.multiselect("Select session(s)", session_names)
+            df_view = (
+                df_all[df_all["Session Name"].isin(chosen)] if chosen else df_all.iloc[0:0]
             )
-        },
-    )
-    if "shot_tags" not in st.session_state:
-        st.session_state["shot_tags"] = {}
-    for _, row in edited.iterrows():
-        st.session_state["shot_tags"][row["_idx"]] = row.get("Quality", "good")
+        exclude_sessions = st.multiselect(
+            "Exclude sessions from analysis",
+            session_names,
+            st.session_state.get("exclude_sessions", []),
+        )
+        st.session_state["exclude_sessions"] = exclude_sessions
 
-    if edited.empty:
-        st.info("No sessions selected.")
+        df_view = classify_shots(df_view)
+        df_view = df_view.reset_index().rename(columns={"index": "_idx"})
+
+        bulk_tag = st.selectbox(
+            "Bulk set quality for all visible shots",
+            ["", "good", "miss", "outlier"],
+        )
+        if st.button("Apply tag") and bulk_tag:
+            df_view["Quality"] = bulk_tag
+
+        edited = st.data_editor(
+            df_view,
+            hide_index=True,
+            key="tag_editor",
+            column_config={
+                "Quality": st.column_config.SelectboxColumn(
+                    "Quality", options=["good", "miss", "outlier"], default="good"
+                )
+            },
+        )
+        if "shot_tags" not in st.session_state:
+            st.session_state["shot_tags"] = {}
+        for _, row in edited.iterrows():
+            st.session_state["shot_tags"][row["_idx"]] = row.get("Quality", "good")
+
+        if edited.empty:
+            st.info("No sessions selected.")
 
 with log_tab:
     st.subheader("Practice Log")

--- a/pages/2_Trends.py
+++ b/pages/2_Trends.py
@@ -37,6 +37,9 @@ summary = (
 )
 
 club_options = sorted(summary["Club"].dropna().unique())
+if not club_options:
+    st.info("No club data available.")
+    st.stop()
 selected_club = st.selectbox("Select club", club_options)
 club_df = summary[summary["Club"] == selected_club].copy()
 

--- a/pages/3_AI_Feedback.py
+++ b/pages/3_AI_Feedback.py
@@ -39,20 +39,23 @@ insight_tab, session_tab = st.tabs(["Club Insight", "Practice Summary"])
 
 with insight_tab:
     club_list = sorted(df["Club"].dropna().unique())
-    selected_club = st.selectbox("Select a club for feedback", club_list)
-    if st.button("Generate Summary"):
-        with st.spinner("Generating AI summary..."):
-            sampled = df[df["Club"] == selected_club].sample(
-                n=min(25, len(df[df["Club"] == selected_club])), random_state=42
-            )
-            feedback = generate_ai_summary(selected_club, sampled)
-            st.session_state[f"ai_{selected_club}"] = feedback
-            st.session_state["ai_files_snapshot"] = uploaded_files
-            st.success("✅ Summary generated!")
-    cached = st.session_state.get(f"ai_{selected_club}")
-    if cached:
-        st.markdown("### 💬 Summary")
-        st.write(cached)
+    if not club_list:
+        st.info("No club data available.")
+    else:
+        selected_club = st.selectbox("Select a club for feedback", club_list)
+        if st.button("Generate Summary"):
+            with st.spinner("Generating AI summary..."):
+                sampled = df[df["Club"] == selected_club].sample(
+                    n=min(25, len(df[df["Club"] == selected_club])), random_state=42
+                )
+                feedback = generate_ai_summary(selected_club, sampled)
+                st.session_state[f"ai_{selected_club}"] = feedback
+                st.session_state["ai_files_snapshot"] = uploaded_files
+                st.success("✅ Summary generated!")
+        cached = st.session_state.get(f"ai_{selected_club}")
+        if cached:
+            st.markdown("### 💬 Summary")
+            st.write(cached)
 
 with session_tab:
     if st.button("Generate Practice Summary"):

--- a/utils/openai_utils.py
+++ b/utils/openai_utils.py
@@ -5,6 +5,8 @@ import os
 
 from openai import OpenAI
 
+from .logger import logger
+
 
 @lru_cache(maxsize=1)
 def get_openai_client() -> OpenAI | None:
@@ -19,8 +21,10 @@ def get_openai_client() -> OpenAI | None:
 
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
+        logger.warning("OPENAI_API_KEY not set; OpenAI features disabled")
         return None
     try:
         return OpenAI(api_key=api_key)
-    except Exception:
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.error("Failed to create OpenAI client: %s", exc)
         return None


### PR DESCRIPTION
## Summary
- Cancel pending session-state timers at shutdown to prevent lingering background threads
- Guard session, trend, and AI feedback pages against empty data lists
- Log OpenAI client initialization issues for easier diagnostics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892398b8a848330b50ecb79baac8250