### PR TITLE
Handle duplicate Club Type columns in drill recommendations

### DIFF
--- a/pages/3_AI_Feedback.py
+++ b/pages/3_AI_Feedback.py
@@ -33,7 +33,7 @@ if set(st.session_state.get("ai_files_snapshot", [])) != set(uploaded_files):
     st.session_state["practice_summary"] = analyze_practice_session(df)
     st.session_state["ai_files_snapshot"] = uploaded_files
 
-drill_map = recommend_drills(df.rename(columns={"Club": "Club Type"}))
+drill_map = recommend_drills(df)
 
 insight_tab, session_tab = st.tabs(["Club Insight", "Practice Summary"])
 

--- a/test_drill_recommendations.py
+++ b/test_drill_recommendations.py
@@ -73,3 +73,17 @@ def test_excessive_wedge_backspin():
     recs = recommend_drills(df)
     issues = [r.issue for r in recs['PW']]
     assert "Excessive wedge backspin" in issues
+
+
+def test_duplicate_club_type_columns_are_handled():
+    df = pd.DataFrame({
+        'Club Type': ['Driver', 'Driver'],
+        'Carry Distance': [230, 232],
+        'Smash Factor': [1.40, 1.46],
+        'Launch Angle': [12, 13],
+        'Club': ['Driver', 'Driver'],
+    })
+    df_dup = df.rename(columns={'Club': 'Club Type'})
+    recs = recommend_drills(df_dup)
+    issues = [r.issue for r in recs['Driver']]
+    assert "Low smash factor" in issues

--- a/utils/drill_recommendations.py
+++ b/utils/drill_recommendations.py
@@ -70,14 +70,21 @@ def recommend_drills(df: pd.DataFrame) -> Dict[str, List[Recommendation]]:
     Parameters
     ----------
     df:
-        DataFrame containing at least ``Club Type``, ``Carry Distance``,
-        ``Smash Factor`` and ``Launch Angle`` columns.
+        DataFrame containing club shot data.  A ``Club Type`` column is
+        expected, but if only ``Club`` is present it will be used instead.
 
     Returns
     -------
     dict
         Mapping of club name to a list of :class:`Recommendation` objects.
     """
+
+    df = df.copy()
+    df = df.loc[:, ~df.columns.duplicated()]
+    if "Club Type" not in df.columns and "Club" in df.columns:
+        df = df.rename(columns={"Club": "Club Type"})
+    if "Club Type" not in df.columns:
+        return {}
 
     recommendations: Dict[str, List[Recommendation]] = {}
 


### PR DESCRIPTION
## Summary
- Avoid duplicate column error in AI Feedback by letting `recommend_drills` deduplicate columns and derive `Club Type` when only `Club` is provided
- Simplify page logic to call `recommend_drills` without manual column rename
- Add regression test ensuring duplicate `Club Type` columns are handled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689284d65ac48330b1df9e5351a954b2