### PR TITLE
Fix session persistence and AI summarization issues

### DIFF
--- a/utils/ai_feedback.py
+++ b/utils/ai_feedback.py
@@ -63,98 +63,19 @@ Explain what this means for my consistency and what to do in practice. Be specif
 
 
 def generate_ai_batch_summaries(df) -> Dict[str, str]:
-    """Generate AI feedback for multiple clubs using a single prompt.
+    """Generate AI feedback for multiple clubs.
 
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        DataFrame containing all shot data with a ``Club`` column.
-
-    Returns
-    -------
-    Dict[str, str]
-        Mapping of club name to the AI generated feedback string. If credentials
-        are missing or an error occurs, each club maps to an error message.
+    This implementation generates one prompt per club using ``generate_ai_summary``
+    to avoid very long prompts that could exceed model token limits.  Returning a
+    mapping of club to summary keeps the public API the same while greatly
+    simplifying parsing of responses.
     """
 
     if "Club" not in df.columns:
         return {}
 
-    clubs = df["Club"].unique().tolist()
-    if not clubs:
-        return {}
-
-    summaries = {club: "" for club in clubs}
-
-    client = get_openai_client()
-    if client is None:
-        return {club: "⚠️ AI credentials missing." for club in clubs}
-
-    # Build a combined prompt with statistics for each club
-    sections = []
+    clubs = df["Club"].dropna().unique().tolist()
+    summaries: Dict[str, str] = {}
     for club in clubs:
-        shots = df[df["Club"] == club]
-        if shots.empty:
-            continue
-        carry_col = "Carry Distance" if "Carry Distance" in shots.columns else "Carry"
-        shots = shots.copy()
-        if carry_col in shots.columns:
-            shots[carry_col] = coerce_numeric(shots[carry_col])
-        for col in ["Smash Factor", "Launch Angle", "Backspin"]:
-            if col in shots.columns:
-                shots[col] = coerce_numeric(shots[col])
-        carry = shots[carry_col].mean() if carry_col in shots.columns else float("nan")
-        smash = shots["Smash Factor"].mean() if "Smash Factor" in shots.columns else float("nan")
-        launch = shots["Launch Angle"].mean() if "Launch Angle" in shots.columns else float("nan")
-        backspin = shots["Backspin"].mean() if "Backspin" in shots.columns else float("nan")
-        std_dev = shots[carry_col].std() if carry_col in shots.columns else float("nan")
-        shot_count = len(shots)
-        section = (
-            f"{club}\n"
-            f"- Carry: {carry:.1f} yds\n"
-            f"- Smash: {smash:.2f}\n"
-            f"- Launch: {launch:.1f}°\n"
-            f"- Backspin: {backspin:.0f} rpm\n"
-            f"- Std Dev (Carry): {std_dev:.1f}\n"
-            f"- Shots: {shot_count}"
-        )
-        sections.append(section)
-
-    if not sections:
-        return {club: "No data for this club." for club in clubs}
-
-    prompt = (
-        "You're a golf performance coach trained in Jon Sherman's Four Foundations. "
-        "I use a Garmin R10. Provide a short, actionable summary for each club "
-        "below. Format your reply as 'Club: summary' for each club.\n\n" + "\n\n".join(sections)
-    )
-
-    try:
-        response = client.chat.completions.create(
-            model="gpt-4o",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.7,
-        )
-        text = response.choices[0].message.content
-        current = None
-        for line in text.splitlines():
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if stripped.endswith(":") and stripped[:-1] in summaries:
-                current = stripped[:-1]
-                summaries[current] = ""
-                continue
-            if ":" in stripped and stripped.split(":", 1)[0] in summaries and summaries[
-                stripped.split(":", 1)[0]
-            ] == "":
-                current, msg = stripped.split(":", 1)
-                current = current.strip()
-                summaries[current] = msg.strip()
-            elif current:
-                summaries[current] += (" " if summaries[current] else "") + stripped
-
-        return {club: (msg.strip() if msg else "⚠️ AI summary error") for club, msg in summaries.items()}
-
-    except Exception as e:
-        return {club: f"⚠️ AI summary error: {e}" for club in clubs}
+        summaries[club] = generate_ai_summary(club, df)
+    return summaries

--- a/utils/session_loader.py
+++ b/utils/session_loader.py
@@ -2,6 +2,7 @@
 
 from typing import List
 
+import os
 from concurrent.futures import ThreadPoolExecutor
 import pandas as pd
 
@@ -51,7 +52,8 @@ def load_sessions(files: List[object]) -> pd.DataFrame:
             )
             return None
 
-    with ThreadPoolExecutor() as pool:
+    max_workers = max(1, min(len(files), (os.cpu_count() or 1)))
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
         sessions = [s for s in pool.map(_load, files) if s]
 
     if not sessions:


### PR DESCRIPTION
## Summary
- Replace background timer with atomic, synchronous cache writes
- Harden cached state loading and file removal checks
- Limit session-loading concurrency and simplify AI batch summaries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c3d7900c83309044d7ec0d8f1f78