### PR TITLE
Enhance analysis metrics and outlier controls

### DIFF
--- a/test_data_utils.py
+++ b/test_data_utils.py
@@ -49,8 +49,16 @@ def test_remove_outliers_custom_threshold():
 def test_remove_outliers_isolation_forest():
     pytest.importorskip("sklearn")
     df = pd.DataFrame({'Metric': [10, 11, 9, 12, 10, 11, 9, 12, 10, 11, 10, 11, 9, 12, 10, 11, 9, 12, 10, 11, 50]})
-    filtered = remove_outliers(df, ['Metric'], method='isolation')
+    filtered = remove_outliers(df, ['Metric'], method='isolation', contamination=0.1)
     assert 50 not in filtered['Metric'].values
+
+
+def test_remove_outliers_iqr_multiplier():
+    df = pd.DataFrame({'Metric': [1, 1, 1, 2, 100]})
+    tight = remove_outliers(df, ['Metric'], z_thresh=3.0, iqr_mult=1.0)
+    assert 100 not in tight['Metric'].values
+    loose = remove_outliers(df, ['Metric'], z_thresh=3.0, iqr_mult=200.0)
+    assert 100 in loose['Metric'].values
 
 
 def test_derive_offline_distance_from_side():


### PR DESCRIPTION
## Summary
- expand club overview with median and percentile stats plus coach thresholds
- add configurable outlier detection with IQR multiplier, contamination tuning, and removed-shot preview
- enrich benchmarking with min/max metrics, trend chart, and adjustable feedback triggers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c4fcffa08330aa0e44a6dafcb8c1