### PR TITLE
Persist uploaded sessions across Streamlit pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,43 @@
+"""Minimal Streamlit application for uploading Garmin R10 CSV files."""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from utils.session_loader import load_sessions
+
+# Basic page configuration
+st.set_page_config(page_title="Garmin R10 Analyzer")
+st.title("\U0001F4CA Garmin R10 Analyzer")
+
+# Ensure a dataframe is always available in session state
+if "session_df" not in st.session_state:
+    st.session_state["session_df"] = pd.DataFrame()
+
+# File uploader allowing multiple CSVs
+uploaded_files = st.file_uploader(
+    "Upload one or more Garmin CSV files",
+    type=["csv"],
+    accept_multiple_files=True,
+)
+
+if uploaded_files:
+    df_new = load_sessions(uploaded_files)
+    if not df_new.empty:
+        if st.session_state["session_df"].empty:
+            st.session_state["session_df"] = df_new
+        else:
+            st.session_state["session_df"] = pd.concat(
+                [st.session_state["session_df"], df_new], ignore_index=True
+            )
+        st.success(
+            f"Loaded {len(df_new['Session Name'].drop_duplicates())} session(s). Navigate using the sidebar."
+        )
+
+# Display a list of sessions currently stored
+if not st.session_state["session_df"].empty:
+    sessions = st.session_state["session_df"]["Session Name"].drop_duplicates().tolist()
+    st.write("Current sessions:", sessions)
+else:
+    st.info("No sessions uploaded yet.")

--- a/test_session_loader.py
+++ b/test_session_loader.py
@@ -15,7 +15,7 @@ def test_load_sessions_names_by_date():
     f2 = _make_file("Date,Club\n2025-08-02 09:00,Driver\n", "b.csv")
     df = load_sessions([f1, f2])
     names = df["Session Name"].drop_duplicates().tolist()
-    assert names == ["2025-08-01", "2025-08-02"]
+    assert names == ["2025-08-01 Session 1", "2025-08-02 Session 1"]
     assert set(df["Source File"].unique()) == {"a.csv", "b.csv"}
     assert "Session ID" in df.columns
     assert len(df["Session ID"].unique()) == 2
@@ -26,5 +26,15 @@ def test_load_sessions_numbers_duplicate_dates():
     earlier = _make_file("Date,Club\n2025-08-01 09:00,Driver\n", "early.csv")
     df = load_sessions([later, earlier])
     names = df["Session Name"].drop_duplicates().tolist()
-    assert names == ["2025-08-01", "2025-08-01 #2"]
+    assert names == ["2025-08-01 Session 1", "2025-08-01 Session 2"]
     assert df["Session ID"].nunique() == 2
+
+
+def test_load_sessions_club_fallback():
+    """If the ``Club`` column is missing the loader should fall back to
+    ``Club Name`` or ``Club Type``."""
+
+    f = _make_file("Date,Club Name\n2025-08-01 10:00,Driver\n", "a.csv")
+    df = load_sessions([f])
+    assert "Club" in df.columns
+    assert df.loc[0, "Club"] == "Driver"


### PR DESCRIPTION
## Summary
- Add Streamlit `app.py` that keeps uploaded CSV data in `st.session_state` so all pages can access it.
- Extend session loader to fall back to `Club Name` or `Club Type` and label multiple same-day uploads as "YYYY-MM-DD Session N".
- Test coverage updated for new session naming and club fallback.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965ff9273083308c6ae86a22ec7e22